### PR TITLE
Update obj_io.py: Make PyTorch3D work with ShapeNetCore.v2

### DIFF
--- a/pytorch3d/io/obj_io.py
+++ b/pytorch3d/io/obj_io.py
@@ -218,6 +218,9 @@ def _parse_face(
 ):
     face = line.split(" ")[1:]
     face_list = [f.split("/") for f in face]
+    # ShapeNetCore v2 fix: remove second blank after face identifier
+    if face_list[0] == ['']:
+        face_list = face_list[1:]
     face_verts = []
     face_normals = []
     face_textures = []

--- a/pytorch3d/io/obj_io.py
+++ b/pytorch3d/io/obj_io.py
@@ -216,11 +216,8 @@ def _parse_face(
     faces_textures_idx,
     faces_materials_idx,
 ):
-    face = line.split(" ")[1:]
+    face = line.split()[1:]
     face_list = [f.split("/") for f in face]
-    # ShapeNetCore v2 fix: remove second blank after face identifier
-    if face_list[0] == ['']:
-        face_list = face_list[1:]
     face_verts = []
     face_normals = []
     face_textures = []


### PR DESCRIPTION
Making PyTorch3D work with ShapeNetCore.v2 models from http://shapenet.cs.stanford.edu/shapenet/obj-zip/ShapeNetCore.v2/
The face identifier of the ShapeNetCore.v2 models is followed by two not one blank - example: 
"f  1/1/1 2/2/2 3/3/3" instead of
"f 1/1/1 2/2/2 3/3/3"