### PR TITLE
create extrinsic from eye point

### DIFF
--- a/pytorch3d/renderer/blending.py
+++ b/pytorch3d/renderer/blending.py
@@ -3,7 +3,7 @@
 
 
 import numpy as np
-from typing import NamedTuple
+from typing import NamedTuple, Sequence
 import torch
 
 # Example functions for blending the top K colors per pixel using the outputs
@@ -15,7 +15,7 @@ import torch
 class BlendParams(NamedTuple):
     sigma: float = 1e-4
     gamma: float = 1e-4
-    background_color = (1.0, 1.0, 1.0)
+    background_color: Sequence = (1.0, 1.0, 1.0)
 
 
 def hard_rgb_blend(colors, fragments) -> torch.Tensor:

--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -1003,9 +1003,9 @@ def look_at_rotation(
 
 
 def look_at_view_transform(
-    dist,
-    elev,
-    azim,
+    dist=1.0,
+    elev=0.0,
+    azim=0.0,
     degrees: bool = True,
     eye: Sequence = None,
     at=((0, 0, 0),),  # (1, 3)

--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -1002,45 +1002,12 @@ def look_at_rotation(
     return R.transpose(1, 2)
 
 
-def look_at_from_eye_view_transform(
-    eye: Sequence,
-    at=((0, 0, 0),),  # (1, 3)
-    up=((0, 1, 0),),  # (1, 3)
-    device="cpu",
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    This function returns a rotation and translation matrix
-    to apply the 'Look At' transformation from world -> view coordinates [0].
-
-    Args:
-        eye: the position of the camera(s) in world coordinates.
-        up: the direction of the x axis in the world coordinate system.
-        at: the position of the object(s) in world coordinates.
-        eye up and at can be of shape (1, 3) or (N, 3).
-
-    Returns:
-        2-element tuple containing
-
-        - **R**: the rotation to apply to the points to align with the camera.
-        - **T**: the translation to apply to the points to align with the camera.
-
-    References:
-    [0] https://www.scratchapixel.com
-    """
-    broadcasted_args = convert_to_tensors_and_broadcast(
-        eye, at, up, device=device
-    )
-    eye, at, up = broadcasted_args
-    R = look_at_rotation(eye, at, up, device=device)
-    T = -torch.bmm(R.transpose(1, 2), eye[:, :, None])[:, :, 0]
-    return R, T
-
-
 def look_at_view_transform(
     dist,
     elev,
     azim,
     degrees: bool = True,
+    eye: Sequence = None,
     at=((0, 0, 0),),  # (1, 3)
     up=((0, 1, 0),),  # (1, 3)
     device="cpu",
@@ -1059,10 +1026,12 @@ def look_at_view_transform(
             reference vector at (1, 0, 0) on the reference plane.
         dist, elem and azim can be of shape (1), (N).
         degrees: boolean flag to indicate if the elevation and azimuth
-            angles are specified in degrees or raidans.
+            angles are specified in degrees or radians.
+        eye: the position of the camera(s) in world coordinates. If eye is not
+            None, it will overide the camera position derived from dist, elev, azim.
         up: the direction of the x axis in the world coordinate system.
         at: the position of the object(s) in world coordinates.
-        up and at can be of shape (1, 3) or (N, 3).
+        eye, up and at can be of shape (1, 3) or (N, 3).
 
     Returns:
         2-element tuple containing
@@ -1073,11 +1042,19 @@ def look_at_view_transform(
     References:
     [0] https://www.scratchapixel.com
     """
-    broadcasted_args = convert_to_tensors_and_broadcast(
-        dist, elev, azim, at, up, device=device
-    )
-    dist, elev, azim, at, up = broadcasted_args
-    C = camera_position_from_spherical_angles(dist, elev, azim, device=device)
+
+    if eye is not None:
+        broadcasted_args = convert_to_tensors_and_broadcast(
+            eye, at, up, device=device)
+        eye, at, up = broadcasted_args
+        C = eye
+    else:
+        broadcasted_args = convert_to_tensors_and_broadcast(
+            dist, elev, azim, at, up, device=device)
+        dist, elev, azim, at, up = broadcasted_args
+        C = camera_position_from_spherical_angles(
+            dist, elev, azim, degrees=degrees, device=device)
+
     R = look_at_rotation(C, at, up, device=device)
     T = -torch.bmm(R.transpose(1, 2), C[:, :, None])[:, :, 0]
     return R, T

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -684,7 +684,3 @@ class TestSfMPerspectiveProjection(TestCaseMixin, unittest.TestCase):
             vertices, fx=2.0, fy=2.0, p0x=2.5, p0y=3.5
         )
         self.assertTrue(torch.allclose(v1, v2))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -122,7 +122,7 @@ class TestCameraHelpers(unittest.TestCase):
         dist = math.sqrt(2)
         elev = math.pi / 4
         azim = 0.0
-        eye = ((0.0, 1.0, -1.0), )
+        eye = ((0.0, 1.0, 1.0), )
         # using passed values for dist, elev, azim
         R, t = look_at_view_transform(dist, elev, azim, degrees=False)
         # using other values for dist, elev, azim - eye overrides

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -134,6 +134,23 @@ class TestCameraHelpers(unittest.TestCase):
         self.assertTrue(torch.allclose(R, R_eye_only, atol=2e-7))
         self.assertTrue(torch.allclose(t, t_eye_only, atol=2e-7))
 
+    def test_look_at_view_transform_default_values(self):
+        dist = 1.0
+        elev = 0.0
+        azim = 0.0
+        # Using passed values for dist, elev, azim
+        R, t = look_at_view_transform(dist, elev, azim)
+        # Using default dist=1.0, elev=0.0, azim=0.0
+        R_default, t_default = look_at_view_transform()
+        # R should be identity, t should be (0, 0, 1)
+        R_expected = torch.tensor([np.eye(3)], dtype=torch.float32)
+        t_expected = torch.tensor([[0.0, 0.0, 1.0]])
+        # test default = passed = expected
+        self.assertTrue(torch.allclose(R, R_default, atol=2e-7))
+        self.assertTrue(torch.allclose(t, t_default, atol=2e-7))
+        self.assertTrue(torch.allclose(R, R_expected, atol=2e-7))
+        self.assertTrue(torch.allclose(t, t_expected, atol=2e-7))
+
     def test_camera_position_from_angles_python_scalar(self):
         dist = 2.7
         elev = 90.0

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -142,14 +142,9 @@ class TestCameraHelpers(unittest.TestCase):
         R, t = look_at_view_transform(dist, elev, azim)
         # Using default dist=1.0, elev=0.0, azim=0.0
         R_default, t_default = look_at_view_transform()
-        # R should be identity, t should be (0, 0, 1)
-        R_expected = torch.tensor([np.eye(3)], dtype=torch.float32)
-        t_expected = torch.tensor([[0.0, 0.0, 1.0]])
         # test default = passed = expected
         self.assertTrue(torch.allclose(R, R_default, atol=2e-7))
         self.assertTrue(torch.allclose(t, t_default, atol=2e-7))
-        self.assertTrue(torch.allclose(R, R_expected, atol=2e-7))
-        self.assertTrue(torch.allclose(t, t_expected, atol=2e-7))
 
     def test_camera_position_from_angles_python_scalar(self):
         dist = 2.7

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -119,16 +119,21 @@ class TestCameraHelpers(unittest.TestCase):
         np.random.seed(42)
 
     def test_look_at_view_transform_from_eye_point_tuple(self):
+        """Test passing eye tuple with and without dist, elev, angle."""
         dist = math.sqrt(2)
         elev = math.pi / 4
         azim = 0.0
         eye = ((0.0, 1.0, -1.0), )
+        # using passed values for dist, elev, azim
         R, t = look_at_view_transform(dist, elev, azim, degrees=False)
-        # using other values for dist, elev, azim
-        R_eye, t_eye = look_at_view_transform(
-            dist=3, elev=2, azim=1, eye=eye)
+        # using other values for dist, elev, azim - eye overrides
+        R_eye, t_eye = look_at_view_transform(dist=3, elev=2, azim=1, eye=eye)
+        # using only eye value
+        R_eye_only, t_eye_only = look_at_view_transform(eye=eye)
         self.assertTrue(torch.allclose(R, R_eye, atol=2e-7))
         self.assertTrue(torch.allclose(t, t_eye, atol=2e-7))
+        self.assertTrue(torch.allclose(R, R_eye_only, atol=2e-7))
+        self.assertTrue(torch.allclose(t, t_eye_only, atol=2e-7))
 
     def test_camera_position_from_angles_python_scalar(self):
         dist = 2.7

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -119,7 +119,6 @@ class TestCameraHelpers(unittest.TestCase):
         np.random.seed(42)
 
     def test_look_at_view_transform_from_eye_point_tuple(self):
-        """Test passing eye tuple with and without dist, elev, angle."""
         dist = math.sqrt(2)
         elev = math.pi / 4
         azim = 0.0

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -39,6 +39,7 @@ from pytorch3d.renderer.cameras import (
     camera_position_from_spherical_angles,
     get_world_to_view_transform,
     look_at_rotation,
+    look_at_view_transform,
 )
 from pytorch3d.transforms import Transform3d
 from pytorch3d.transforms.so3 import so3_exponential_map
@@ -116,6 +117,18 @@ class TestCameraHelpers(unittest.TestCase):
         super().setUp()
         torch.manual_seed(42)
         np.random.seed(42)
+
+    def test_look_at_view_transform_from_eye_point_tuple(self):
+        dist = math.sqrt(2)
+        elev = math.pi / 4
+        azim = 0.0
+        eye = ((0.0, 1.0, -1.0), )
+        R, t = look_at_view_transform(dist, elev, azim, degrees=False)
+        # using other values for dist, elev, azim
+        R_eye, t_eye = look_at_view_transform(
+            dist=3, elev=2, azim=1, eye=eye)
+        self.assertTrue(torch.allclose(R, R_eye, atol=2e-7))
+        self.assertTrue(torch.allclose(t, t_eye, atol=2e-7))
 
     def test_camera_position_from_angles_python_scalar(self):
         dist = 2.7
@@ -671,3 +684,7 @@ class TestSfMPerspectiveProjection(TestCaseMixin, unittest.TestCase):
             vertices, fx=2.0, fy=2.0, p0x=2.5, p0y=3.5
         )
         self.assertTrue(torch.allclose(v1, v2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Create extrinsic parameters from eye point.
Create the rotation and translation from an eye point, look-at point and up vector.
see:
https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluLookAt.xml

It is arguably easier to initialise a camera position as a point in the world rather than an angle.