### PR TITLE
Fix squared distance for CPU impl.

### DIFF
--- a/pytorch3d/csrc/rasterize_meshes/geometry_utils.h
+++ b/pytorch3d/csrc/rasterize_meshes/geometry_utils.h
@@ -271,7 +271,7 @@ T PointLineDistanceForward(
   const vec2<T> v1v0 = v1 - v0;
   const T l2 = dot(v1v0, v1v0);
   if (l2 <= kEpsilon) {
-    return sqrt(dot(p - v1, p - v1));
+    return dot(p - v1, p - v1);
   }
 
   const T t = dot(v1v0, p - v0) / l2;

--- a/pytorch3d/renderer/mesh/rasterize_meshes.py
+++ b/pytorch3d/renderer/mesh/rasterize_meshes.py
@@ -445,8 +445,8 @@ def point_line_distance(p, v0, v1):
 
     v1v0 = v1 - v0
     l2 = v1v0.dot(v1v0)  # |v1 - v0|^2
-    if l2 == 0.0:
-        return torch.sqrt((p - v1).dot(p - v1))  # v0 == v1
+    if l2 <= kEpsilon:
+        return (p - v1).dot(p - v1)  # v0 == v1
 
     t = (v1v0).dot(p - v0) / l2
     t = torch.clamp(t, min=0.0, max=1.0)


### PR DESCRIPTION
`PointLineDistanceForward()` should return squared distance. However, it seems that it returned non-squared distance when `v0` was near by `v1` in CPU implementation.