### PR TITLE
a formula for bin size for images over 64x64

### DIFF
--- a/pytorch3d/renderer/mesh/rasterize_meshes.py
+++ b/pytorch3d/renderer/mesh/rasterize_meshes.py
@@ -97,12 +97,11 @@ def rasterize_meshes(
             # TODO better heuristics for bin size.
             if image_size <= 64:
                 bin_size = 8
-            elif image_size <= 256:
-                bin_size = 16
-            elif image_size <= 512:
-                bin_size = 32
-            elif image_size <= 1024:
-                bin_size = 64
+            else:
+                bin_size = int(2 ** max(np.ceil(np.log2(image_size)) - 4, 4))
+
+    if bin_size != 0:
+        assert 1 + (image_size - 1) // bin_size < 22
 
     if max_faces_per_bin is None:
         max_faces_per_bin = int(max(10000, verts_packed.shape[0] / 5))

--- a/pytorch3d/renderer/mesh/rasterize_meshes.py
+++ b/pytorch3d/renderer/mesh/rasterize_meshes.py
@@ -101,7 +101,9 @@ def rasterize_meshes(
                 bin_size = int(2 ** max(np.ceil(np.log2(image_size)) - 4, 4))
 
     if bin_size != 0:
-        assert 1 + (image_size - 1) // bin_size < 22
+        v = 1 + (image_size - 1) // bin_size
+        if v >= 22:
+            raise ValueError("bin size too small, number of faces per pixel must be less than 22")
 
     if max_faces_per_bin is None:
         max_faces_per_bin = int(max(10000, verts_packed.shape[0] / 5))


### PR DESCRIPTION
Signed-off-by: Michele Sanna <sanna@arrival.com>

fixes the bin_size calculation with a formula for any image_size > 64. Matches the values chosen so far.

simple test:

```
import numpy as np
import matplotlib.pyplot as plt

image_size = np.arange(64, 2048)
bin_size = np.where(image_size <= 64, 8, (2 ** np.maximum(np.ceil(np.log2(image_size)) - 4, 4)).astype(int))

print(image_size)
print(bin_size)


for ims, bins in zip(image_size, bin_size):
    if ims <= 64:
        assert bins == 8
    elif ims <= 256:
        assert bins == 16
    elif ims <= 512:
        assert bins == 32
    elif ims <= 1024:
        assert bins == 64
    elif ims <= 2048:
        assert bins == 128

    assert (ims + bins - 1) // bins < 22


plt.plot(image_size, bin_size)
plt.grid()
plt.show()
```

![img](https://user-images.githubusercontent.com/54891577/75464693-795bcf00-597f-11ea-9061-26440211691c.png)


