### PR TITLE
Fix docs, function comments and function names that incorrectly descr…

### DIFF
--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -23,9 +23,9 @@ class OpenGLPerspectiveCameras(TensorProperties):
 
     The extrinsics of the camera (R and T matrices) can also be set in the
     initializer or passed in to `get_full_projection_transform` to get
-    the full transformation from world -> screen.
+    the full transformation from world -> NDC.
 
-    The `transform_points` method calculates the full world -> screen transform
+    The `transform_points` method calculates the full world -> NDC transform
     and then applies it to the input points.
 
     The transforms can also be returned separately as Transform3d objects.
@@ -212,8 +212,8 @@ class OpenGLPerspectiveCameras(TensorProperties):
 
     def get_full_projection_transform(self, **kwargs) -> Transform3d:
         """
-        Return the full world-to-screen transform composing the
-        world-to-view and view-to-screen transforms.
+        Return the full world-to-NDC transform composing the
+        world-to-view and view-to-NDC transforms.
 
         Args:
             **kwargs: parameters for the projection transforms can be passed in
@@ -233,12 +233,12 @@ class OpenGLPerspectiveCameras(TensorProperties):
         world_to_view_transform = self.get_world_to_view_transform(
             R=self.R, T=self.T
         )
-        view_to_screen_transform = self.get_projection_transform(**kwargs)
-        return world_to_view_transform.compose(view_to_screen_transform)
+        view_to_ndc_transform = self.get_projection_transform(**kwargs)
+        return world_to_view_transform.compose(view_to_ndc_transform)
 
     def transform_points(self, points, **kwargs) -> torch.Tensor:
         """
-        Transform input points from world to screen space.
+        Transform input points from world to NDC space.
 
         Args:
             points: torch tensor of shape (..., 3).
@@ -246,8 +246,8 @@ class OpenGLPerspectiveCameras(TensorProperties):
         Returns
             new_points: transformed points with the same shape as the input.
         """
-        world_to_screen_transform = self.get_full_projection_transform(**kwargs)
-        return world_to_screen_transform.transform_points(points)
+        world_to_ndc_transform = self.get_full_projection_transform(**kwargs)
+        return world_to_ndc_transform.transform_points(points)
 
 
 class OpenGLOrthographicCameras(TensorProperties):
@@ -425,8 +425,8 @@ class OpenGLOrthographicCameras(TensorProperties):
 
     def get_full_projection_transform(self, **kwargs) -> Transform3d:
         """
-        Return the full world-to-screen transform composing the
-        world-to-view and view-to-screen transforms.
+        Return the full world-to-NDC transform composing the
+        world-to-view and view-to-NDC transforms.
 
         Args:
             **kwargs: parameters for the projection transforms can be passed in
@@ -446,12 +446,12 @@ class OpenGLOrthographicCameras(TensorProperties):
         world_to_view_transform = self.get_world_to_view_transform(
             R=self.R, T=self.T
         )
-        view_to_screen_transform = self.get_projection_transform(**kwargs)
-        return world_to_view_transform.compose(view_to_screen_transform)
+        view_to_ndc_transform = self.get_projection_transform(**kwargs)
+        return world_to_view_transform.compose(view_to_ndc_transform)
 
     def transform_points(self, points, **kwargs) -> torch.Tensor:
         """
-        Transform input points from world to screen space.
+        Transform input points from world to NDC space.
 
         Args:
             points: torch tensor of shape (..., 3).
@@ -459,8 +459,8 @@ class OpenGLOrthographicCameras(TensorProperties):
         Returns
             new_points: transformed points with the same shape as the input.
         """
-        world_to_screen_transform = self.get_full_projection_transform(**kwargs)
-        return world_to_screen_transform.transform_points(points)
+        world_to_ndc_transform = self.get_full_projection_transform(**kwargs)
+        return world_to_ndc_transform.transform_points(points)
 
 
 class SfMPerspectiveCameras(TensorProperties):
@@ -597,8 +597,8 @@ class SfMPerspectiveCameras(TensorProperties):
 
     def get_full_projection_transform(self, **kwargs) -> Transform3d:
         """
-        Return the full world-to-screen transform composing the
-        world-to-view and view-to-screen transforms.
+        Return the full world-to-NDC transform composing the
+        world-to-view and view-to-NDC transforms.
 
         Args:
             **kwargs: parameters for the projection transforms can be passed in
@@ -614,12 +614,12 @@ class SfMPerspectiveCameras(TensorProperties):
         world_to_view_transform = self.get_world_to_view_transform(
             R=self.R, T=self.T
         )
-        view_to_screen_transform = self.get_projection_transform(**kwargs)
-        return world_to_view_transform.compose(view_to_screen_transform)
+        view_to_ndc_transform = self.get_projection_transform(**kwargs)
+        return world_to_view_transform.compose(view_to_ndc_transform)
 
     def transform_points(self, points, **kwargs) -> torch.Tensor:
         """
-        Transform input points from world to screen space.
+        Transform input points from world to NDC space.
 
         Args:
             points: torch tensor of shape (..., 3).
@@ -627,8 +627,8 @@ class SfMPerspectiveCameras(TensorProperties):
         Returns
             new_points: transformed points with the same shape as the input.
         """
-        world_to_screen_transform = self.get_full_projection_transform(**kwargs)
-        return world_to_screen_transform.transform_points(points)
+        world_to_ndc_transform = self.get_full_projection_transform(**kwargs)
+        return world_to_ndc_transform.transform_points(points)
 
 
 class SfMOrthographicCameras(TensorProperties):
@@ -765,8 +765,8 @@ class SfMOrthographicCameras(TensorProperties):
 
     def get_full_projection_transform(self, **kwargs) -> Transform3d:
         """
-        Return the full world-to-screen transform composing the
-        world-to-view and view-to-screen transforms.
+        Return the full world-to-NDC transform composing the
+        world-to-view and view-to-NDC transforms.
 
         Args:
             **kwargs: parameters for the projection transforms can be passed in
@@ -782,12 +782,12 @@ class SfMOrthographicCameras(TensorProperties):
         world_to_view_transform = self.get_world_to_view_transform(
             R=self.R, T=self.T
         )
-        view_to_screen_transform = self.get_projection_transform(**kwargs)
-        return world_to_view_transform.compose(view_to_screen_transform)
+        view_to_ndc_transform = self.get_projection_transform(**kwargs)
+        return world_to_view_transform.compose(view_to_ndc_transform)
 
     def transform_points(self, points, **kwargs) -> torch.Tensor:
         """
-        Transform input points from world to screen space.
+        Transform input points from world to NDC space.
 
         Args:
             points: torch tensor of shape (..., 3).
@@ -795,8 +795,8 @@ class SfMOrthographicCameras(TensorProperties):
         Returns
             new_points: transformed points with the same shape as the input.
         """
-        world_to_screen_transform = self.get_full_projection_transform(**kwargs)
-        return world_to_screen_transform.transform_points(points)
+        world_to_ndc_transform = self.get_full_projection_transform(**kwargs)
+        return world_to_ndc_transform.transform_points(points)
 
 
 # SfMCameras helper

--- a/pytorch3d/renderer/mesh/rasterize_meshes.py
+++ b/pytorch3d/renderer/mesh/rasterize_meshes.py
@@ -212,6 +212,8 @@ def pix_to_ndc(i, S):
     # NDC x-offset + (i * pixel_width + half_pixel_width)
     return -1 + (2 * i + 1.0) / S
 
+def ndc_to_pix(i, S):
+    return ( (i + 1) * S - 1.0 ) / 2.0
 
 def rasterize_meshes_python(
     meshes,


### PR DESCRIPTION
Fix docs, function comments and function names that incorrectly describe screen space when they should describe NDC space. Add ndc_to_pix function in rasterize_meshes.py.

ndx_to_pix is not used anywhere in the current codebase and is just used as a util for getting from world -> screen.
i.e.
`ndc_coords = cameras.transform_points(world_coords)
pix_coords = ndx_to_pix(ndc_coords) `