### PR TITLE
SfMPerspectiveCameras projection matrix bug fix

### DIFF
--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -505,8 +505,8 @@ class SfMPerspectiveCameras(TensorProperties):
             py = principal_point[:,1]
 
             P = [
-                    [fx,   0,    0,  px],
-                    [0,   fy,    0,  py],
+                    [fx,   0,   px,   0],
+                    [0,   fy,   py,   0],
                     [0,    0,    0,   1],
                     [0,    0,    1,   0],
             ]
@@ -800,8 +800,8 @@ def _get_sfm_calibration_matrix(
                 ]
             else:
                 K = [
-                        [fx,   0,    0,  px],
-                        [0,   fy,    0,  py],
+                        [fx,   0,   px,   0],
+                        [0,   fy,   py,   0],
                         [0,    0,    0,   1],
                         [0,    0,    1,   0],
                 ]
@@ -827,12 +827,14 @@ def _get_sfm_calibration_matrix(
     K = fx.new_zeros(N, 4, 4)
     K[:, 0, 0] = fx
     K[:, 1, 1] = fy
-    K[:, 0, 3] = px
-    K[:, 1, 3] = py
     if orthographic:
+        K[:, 0, 3] = px
+        K[:, 1, 3] = py
         K[:, 2, 2] = 1.0
         K[:, 3, 3] = 1.0
     else:
+        K[:, 0, 2] = px
+        K[:, 1, 2] = py
         K[:, 3, 2] = 1.0
         K[:, 2, 3] = 1.0
 

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -81,8 +81,8 @@ def sfm_perspective_project_naive(points, fx=1.0, fy=1.0, p0x=0.0, p0y=0.0):
         (N, V, 3) tensor of projected points.
     """
     z = points[:, :, 2]
-    x = (points[:, :, 0] * fx + p0x) / z
-    y = (points[:, :, 1] * fy + p0y) / z
+    x = (points[:, :, 0] * fx) / z + p0x
+    y = (points[:, :, 1] * fy) / z + p0y
     points = torch.stack((x, y, 1.0 / z), dim=2)
     return points
 


### PR DESCRIPTION
Fixed a bug in creating the projection matrix for the SfMPerspectiveCameras class. Also fixed the corresponding test in test_cameras.py.

The p0x, p0y are 2D coordinates for the principal point in the NDCS, and therefore should be added AFTER the perspective z divide. I.e. we expect

<a href="https://www.codecogs.com/eqnedit.php?latex=\begin{bmatrix}&space;x\\&space;y\\&space;z&space;\end{bmatrix}_{\text{NDCS}}&space;=&space;\begin{bmatrix}&space;f_xX/Z&space;&plus;&space;p_x\\&space;f_yY/Z&space;&plus;&space;p_y\\&space;1&space;/&space;Z\\&space;\end{bmatrix}&space;=&space;\text{normalize}\left(&space;\begin{bmatrix}&space;f_xX&space;&plus;&space;p_xZ\\&space;f_yY&space;&plus;&space;p_yZ\\&space;1\\&space;Z&space;\end{bmatrix}&space;\right)" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\begin{bmatrix}&space;x\\&space;y\\&space;z&space;\end{bmatrix}_{\text{NDCS}}&space;=&space;\begin{bmatrix}&space;f_xX/Z&space;&plus;&space;p_x\\&space;f_yY/Z&space;&plus;&space;p_y\\&space;1&space;/&space;Z\\&space;\end{bmatrix}&space;=&space;\text{normalize}\left(&space;\begin{bmatrix}&space;f_xX&space;&plus;&space;p_xZ\\&space;f_yY&space;&plus;&space;p_yZ\\&space;1\\&space;Z&space;\end{bmatrix}&space;\right)" title="\begin{bmatrix} x\\ y\\ z \end{bmatrix}_{\text{NDCS}} = \begin{bmatrix} f_xX/Z + p_x\\ f_yY/Z + p_y\\ 1 / Z\\ \end{bmatrix} = \text{normalize}\left( \begin{bmatrix} f_xX + p_xZ\\ f_yY + p_yZ\\ 1\\ Z \end{bmatrix} \right)" /></a>

The current behavior is 

<a href="https://www.codecogs.com/eqnedit.php?latex=\begin{bmatrix}&space;x\\&space;y\\&space;z&space;\end{bmatrix}_{\text{NDCS}}&space;=&space;\begin{bmatrix}&space;f_xX/Z&space;&plus;&space;p_x/Z\\&space;f_yY/Z&space;&plus;&space;p_y/Z\\&space;1&space;/&space;Z\\&space;\end{bmatrix}&space;=&space;\text{normalize}\left(&space;\begin{bmatrix}&space;f_xX&space;&plus;&space;p_x\\&space;f_yY&space;&plus;&space;p_y\\&space;1\\&space;Z&space;\end{bmatrix}&space;\right)" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\begin{bmatrix}&space;x\\&space;y\\&space;z&space;\end{bmatrix}_{\text{NDCS}}&space;=&space;\begin{bmatrix}&space;f_xX/Z&space;&plus;&space;p_x/Z\\&space;f_yY/Z&space;&plus;&space;p_y/Z\\&space;1&space;/&space;Z\\&space;\end{bmatrix}&space;=&space;\text{normalize}\left(&space;\begin{bmatrix}&space;f_xX&space;&plus;&space;p_x\\&space;f_yY&space;&plus;&space;p_y\\&space;1\\&space;Z&space;\end{bmatrix}&space;\right)" title="\begin{bmatrix} x\\ y\\ z \end{bmatrix}_{\text{NDCS}} = \begin{bmatrix} f_xX/Z + p_x/Z\\ f_yY/Z + p_y/Z\\ 1 / Z\\ \end{bmatrix} = \text{normalize}\left( \begin{bmatrix} f_xX + p_x\\ f_yY + p_y\\ 1\\ Z \end{bmatrix} \right)" /></a>

which is incorrect.