### PR TITLE
use screen coords instead of world coords when interpolating the z buffer

### DIFF
--- a/pytorch3d/renderer/mesh/renderer.py
+++ b/pytorch3d/renderer/mesh/renderer.py
@@ -55,8 +55,9 @@ class MeshRenderer(nn.Module):
             # if no downstream functions requires unclipped values.
             # This will avoid unnecssary re-interpolation of the z buffer.
             clipped_bary_coords = _clip_barycentric_coordinates(fragments.bary_coords)
+            meshes_screen = self.rasterizer.transform(meshes_world, **kwargs)
             clipped_zbuf = _interpolate_zbuf(
-                fragments.pix_to_face, clipped_bary_coords, meshes_world
+                fragments.pix_to_face, clipped_bary_coords, meshes_screen
             )
             fragments = Fragments(
                 bary_coords=clipped_bary_coords,


### PR DESCRIPTION
Should fix the following issue:
https://github.com/facebookresearch/pytorch3d/issues/95
