### PR TITLE
Fix look_at_view_transform when object location is not (0,0,0)

### DIFF
--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -974,7 +974,7 @@ def look_at_view_transform(
         dist, elev, azim, at, up = broadcasted_args
         C = camera_position_from_spherical_angles(
             dist, elev, azim, degrees=degrees, device=device
-        )
+        ) + at
 
     R = look_at_rotation(C, at, up, device=device)
     T = -torch.bmm(R.transpose(1, 2), C[:, :, None])[:, :, 0]


### PR DESCRIPTION
The look_at_view_transform did not give the correct results when the object location `at` was not (0,0,0).

The problem was on computing the cameras' location in world's coordinate `C`. It only took into account the camera position from spherical angles, but ignored the object location in the world's coordinate system. I simply modified the C tensor to take into account the object's location which is not necessarily in the origin.

I ran unit tests and all but 4 failed with the same error message: `RuntimeError: CUDA error: invalid device ordinal`. However the same happens before this patch, so I believe these errors are unrelated.