### PR TITLE
Fixing look_at_view_transform documentation, azim angle definition was incorrect

### DIFF
--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -943,7 +943,7 @@ def look_at_view_transform(
         azim: angle in degrees or radians. The vector from the object to
             the camera is projected onto a horizontal plane y = 0.
             azim is the angle between the projected vector and a
-            reference vector at (1, 0, 0) on the reference plane (the horizontal plane).
+            reference vector at (0, 0, 1) on the reference plane (the horizontal plane).
         dist, elem and azim can be of shape (1), (N).
         degrees: boolean flag to indicate if the elevation and azimuth
             angles are specified in degrees or radians.


### PR DESCRIPTION
…between the projection on the y=0 plane and reference vector (0,0,1).

Fixes https://github.com/facebookresearch/pytorch3d/issues/229
