### PR TITLE
Two minor fixes in doc and tutorial

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,7 +71,7 @@ CUDA support will be included if CUDA is enabled or if the environment variable
 
 ### 1. Install from GitHub
 ```
-pip install 'git+https://github.com/facebookresearch/pytorch3d.git'
+pip install "git+https://github.com/facebookresearch/pytorch3d.git"
 ```
 
 **Install from Github on macOS:**

--- a/docs/tutorials/camera_position_optimization_with_differentiable_rendering.ipynb
+++ b/docs/tutorials/camera_position_optimization_with_differentiable_rendering.ipynb
@@ -346,7 +346,7 @@
     "        self.renderer = renderer\n",
     "        \n",
     "        # Get the silhouette of the reference RGB image by finding all the non zero values. \n",
-    "        image_ref = torch.from_numpy((image_ref[..., :3].max(-1) != 0).astype(np.float32))\n",
+    "        image_ref = torch.from_numpy((image_ref[..., :3].max(-1) != 1).astype(np.float32))\n",
     "        self.register_buffer('image_ref', image_ref)\n",
     "        \n",
     "        # Create an optimizable parameter for the x, y, z position of the camera. \n",


### PR DESCRIPTION
`INSTALL.md` On Windows, pip install from git does not work with single quotes. I replace them with double quote as those should work for any OS.

`camera_position_optimization_with_differentiable_rendering.ipynb` To extract the silhouette from the reference image, we need to reject white values, not black values, because the background of the ref is white:
![ref](https://user-images.githubusercontent.com/5802849/86496925-b72e9100-bd7f-11ea-9f61-72abb3efe1b5.png)
