### PR TITLE
Fix 404 link in Renderer Doc

### DIFF
--- a/docs/notes/renderer.md
+++ b/docs/notes/renderer.md
@@ -23,7 +23,7 @@ Our implementation decouples the rasterization and shading steps of rendering. T
 
 ## <u>Get started</u>
 
-To learn about more the implementation and start using the renderer refer to [renderer_getting_started.md](renderer_getting_started.md), which also contains the [architecture overview](assets/architecture_overview.png) and [coordinate transformation conventions](assets/transformations_overview.png).
+To learn about more the implementation and start using the renderer refer to [getting started with renderer](renderer_getting_started.md), which also contains the [architecture overview](assets/architecture_overview.png) and [coordinate transformation conventions](assets/transformations_overview.png).
 
 
 ## <u>Key features</u>

--- a/docs/notes/renderer_getting_started.md
+++ b/docs/notes/renderer_getting_started.md
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Getting Started
 ---
 
-# Renderer Getting Started
+# Getting Started With Renderer
 
 ### Architecture Overview
 


### PR DESCRIPTION
Because of the way Sphinx was parsing this link in Markdown, the link wasn't working properly. This should fix it. 