### PR TITLE
Save obj With Texture

### DIFF
--- a/pytorch3d/io/obj_io.py
+++ b/pytorch3d/io/obj_io.py
@@ -12,8 +12,19 @@ import torch
 from pytorch3d.io.mtl_io import load_mtl, make_mesh_texture_atlas
 from pytorch3d.io.utils import _check_faces_indices, _make_tensor, _open_file
 from pytorch3d.renderer import TexturesAtlas, TexturesUV
-from pytorch3d.structures import Meshes, join_meshes_as_batch
+from pytorch3d.structures import Meshes, Textures, join_meshes_as_batch
+from torchvision import transforms
 
+
+def _make_tensor(data, cols: int, dtype: torch.dtype, device="cpu") -> torch.Tensor:
+    """
+    Return a 2D tensor with the specified cols and dtype filled with data,
+    even when data is empty.
+    """
+    if not data:
+        return torch.zeros((0, cols), dtype=dtype, device=device)
+
+    return torch.tensor(data, dtype=dtype, device=device)
 
 # Faces & Aux type returned from load_obj function.
 _Faces = namedtuple("Faces", "verts_idx normals_idx textures_idx materials_idx")
@@ -511,7 +522,8 @@ def _load_obj(
     return verts, faces, aux
 
 
-def save_obj(f, verts, faces, decimal_places: Optional[int] = None):
+def save_obj(f, verts, faces, decimal_places: Optional[int] = None, verts_uvs: Optional[list] = None,
+             faces_uvs: Optional[list] = None, texture_map: Optional[list] = None):
     """
     Save a mesh to an .obj file.
 
@@ -520,7 +532,16 @@ def save_obj(f, verts, faces, decimal_places: Optional[int] = None):
         verts: FloatTensor of shape (V, 3) giving vertex coordinates.
         faces: LongTensor of shape (F, 3) giving faces.
         decimal_places: Number of decimal places for saving.
+                verts_uvs: (V, 2) tensor giving the uv coordinate per vertex.
+        faces_uvs: (F, 3) tensor giving the index into verts_uvs for each
+                vertex in the face. Padding value is assumed to be -1.
+        texture_map:  padded tensor of shape (1, H, W, 3).
     """
+    use_texture = verts_uvs is not None and texture_map is not None and faces_uvs is not None
+    if use_texture:
+        output_path = pathlib.Path(f)
+        obj_header = '\nmtllib {0}.mtl\nusemtl mesh\n\n'.format(output_path.stem)
+
     if len(verts) and not (verts.dim() == 2 and verts.size(1) == 3):
         message = "Argument 'verts' should either be empty or of shape (num_verts, 3)."
         raise ValueError(message)
@@ -529,12 +550,51 @@ def save_obj(f, verts, faces, decimal_places: Optional[int] = None):
         message = "Argument 'faces' should either be empty or of shape (num_faces, 3)."
         raise ValueError(message)
 
-    with _open_file(f, "w") as f:
-        return _save(f, verts, faces, decimal_places)
+
+    new_f = False
+    if isinstance(f, str):
+        new_f = True
+        f = open(f, "w")
+    elif isinstance(f, pathlib.Path):
+        new_f = True
+        f = f.open("w")
+    try:
+        if use_texture:
+            f.write(obj_header)
+        _save(f, verts, faces, decimal_places, verts_uvs, texture_map, faces_uvs, use_texture)
+    finally:
+        if new_f:
+            f.close()
+    new_f = False
+
+    if use_texture:
+        try:
+            # Save texture map to output folder
+            transforms.ToPILImage()(texture_map.squeeze().cpu().permute(2, 0, 1)).save(
+                output_path.parent / (output_path.stem + '.png'))
+
+            # Create .mtl file linking obj with texture map
+            # This potentially could get expanded with different materials etc.
+            f_mtl = open(output_path.parent / (output_path.stem + '.mtl'), "w")
+            new_f = True
+
+            lines = f'newmtl mesh\n' \
+                    f'map_Kd {output_path.stem}.png\n' \
+                    f'# Test colors\n' \
+                    f'Ka 1.000 1.000 1.000  # white\n' \
+                    f'Kd 1.000 1.000 1.000  # white\n' \
+                    f'Ks 0.000 0.000 0.000  # black\n' \
+                    f'Ns 10.0\n'
+
+            f_mtl.write(lines)
+        finally:
+            if new_f:
+                f_mtl.close()
 
 
 # TODO (nikhilar) Speed up this function.
-def _save(f, verts, faces, decimal_places: Optional[int] = None) -> None:
+def _save(f, verts, faces, decimal_places: Optional[int] = None, verts_uvs: Optional[list] = None,
+          texture_map: Optional[list] = None, faces_uvs: Optional[list] = None, use_texture=False) -> None:
     assert not len(verts) or (verts.dim() == 2 and verts.size(1) == 3)
     assert not len(faces) or (faces.dim() == 2 and faces.size(1) == 3)
 
@@ -556,6 +616,19 @@ def _save(f, verts, faces, decimal_places: Optional[int] = None) -> None:
         for i in range(V):
             vert = [float_str % verts[i, j] for j in range(D)]
             lines += "v %s\n" % " ".join(vert)
+    if use_texture:
+
+        verts_uvs, texture_map, faces_uvs = verts_uvs.cpu(), texture_map.squeeze().cpu(), faces_uvs.cpu()
+        assert not len(verts_uvs) or (verts_uvs.dim() == 2 and verts_uvs.size(1) == 2)
+        assert not len(faces_uvs) or (faces_uvs.dim() == 2 and faces_uvs.size(1) == 3)
+        assert texture_map.dim() == 3 and texture_map.size(2) == 3
+
+        # Save vertices UVs
+        if len(verts_uvs):
+            uV, uD = verts_uvs.shape
+            for i in range(uV):
+                uv = [float_str % verts_uvs[i, j] for j in range(uD)]
+                lines += "vt %s\n" % " ".join(uv)
 
     if torch.any(faces >= verts.shape[0]) or torch.any(faces < 0):
         warnings.warn("Faces have invalid indices")
@@ -563,9 +636,15 @@ def _save(f, verts, faces, decimal_places: Optional[int] = None) -> None:
     if len(faces):
         F, P = faces.shape
         for i in range(F):
-            face = ["%d" % (faces[i, j] + 1) for j in range(P)]
+            if use_texture:
+                # link faces with faces UVs
+                face = ["%d/%d" % (faces[i, j] + 1, faces_uvs[i, j] + 1) for j in range(P)]
+            else:
+                face = ["%d" % (faces[i, j] + 1) for j in range(P)]
+
             if i + 1 < F:
                 lines += "f %s\n" % " ".join(face)
+
             elif i + 1 == F:
                 # No newline at the end of the file.
                 lines += "f %s" % " ".join(face)

--- a/pytorch3d/io/obj_io.py
+++ b/pytorch3d/io/obj_io.py
@@ -6,7 +6,7 @@ import os
 import warnings
 from collections import namedtuple
 from typing import Optional
-
+import pathlib
 import numpy as np
 import torch
 from pytorch3d.io.mtl_io import load_mtl, make_mesh_texture_atlas

--- a/pytorch3d/io/obj_io.py
+++ b/pytorch3d/io/obj_io.py
@@ -12,7 +12,7 @@ import torch
 from pytorch3d.io.mtl_io import load_mtl, make_mesh_texture_atlas
 from pytorch3d.io.utils import _check_faces_indices, _make_tensor, _open_file
 from pytorch3d.renderer import TexturesAtlas, TexturesUV
-from pytorch3d.structures import Meshes, Textures, join_meshes_as_batch
+from pytorch3d.structures import Meshes, join_meshes_as_batch
 from torchvision import transforms
 
 

--- a/tests/test_vert_align.py
+++ b/tests/test_vert_align.py
@@ -22,7 +22,7 @@ class TestVertAlign(TestCaseMixin, unittest.TestCase):
         if torch.is_tensor(feats):
             feats = [feats]
         N = feats[0].shape[0]
-
+#
         out_feats = []
         # sample every example in the batch separately
         for i in range(N):

--- a/tests/test_vert_align.py
+++ b/tests/test_vert_align.py
@@ -22,7 +22,7 @@ class TestVertAlign(TestCaseMixin, unittest.TestCase):
         if torch.is_tensor(feats):
             feats = [feats]
         N = feats[0].shape[0]
-#
+
         out_feats = []
         # sample every example in the batch separately
         for i in range(N):


### PR DESCRIPTION
added the ability to save an .obj file with texture to save_obj function.

of course it is optional and save_obj functionality remained the same if one
chooses to save an .obj without texture

in addition, I added a test the will load the cow mesh and export all artifacts to data folder in tests:

.obj file
.mtl file linking the texture map and the obj
.png file - that is the texture map