### PR TITLE
CamerasBase.transform_points_screen does not respect non-square images

### DIFF
--- a/pytorch3d/__init__.py
+++ b/pytorch3d/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
-__version__ = "0.4.0-93eb348"
+__version__ = "0.4.0"

--- a/pytorch3d/__init__.py
+++ b/pytorch3d/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pytorch3d/__init__.py
+++ b/pytorch3d/__init__.py
@@ -1,3 +1,3 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
-__version__ = "0.4.1"
+__version__ = "0.4.0-93eb348"


### PR DESCRIPTION
# What

CamerasBase.transform_points_screen uses an NDC range for each dimension of -1,1.  However, when you are rendering non-square images those ranges change.  This PR modifies CamerasBase.transform_points_screen to use the pytorch3d.renderer.mesh.rasterize_meshes.non_square_ndc_range function to compute the correct image space points that correspond to the locations in the rendered image.