### PR TITLE
Texture Vertex.num_verts_per_mesh deep copy when num_verts_per_mesh is a list 

### DIFF
--- a/pytorch3d/renderer/mesh/textures.py
+++ b/pytorch3d/renderer/mesh/textures.py
@@ -1286,7 +1286,7 @@ class TexturesVertex(TexturesBase):
         num_verts = (
             self._num_verts_per_mesh.clone()
             if torch.is_tensor(self._num_verts_per_mesh)
-            else self._num_verts_per_mesh
+            else self._num_verts_per_mesh.copy()
         )
         tex._num_verts_per_mesh = num_verts
         tex.valid = self.valid.clone()
@@ -1299,7 +1299,7 @@ class TexturesVertex(TexturesBase):
         num_verts = (
             self._num_verts_per_mesh.detach()
             if torch.is_tensor(self._num_verts_per_mesh)
-            else self._num_verts_per_mesh
+            else self._num_verts_per_mesh.copy()
         )
         tex._num_verts_per_mesh = num_verts
         tex.valid = self.valid.detach()
@@ -1414,7 +1414,7 @@ class TexturesVertex(TexturesBase):
 
         verts_features_list = []
         verts_features_list += self.verts_features_list()
-        num_faces_per_mesh = self._num_verts_per_mesh
+        num_faces_per_mesh = self._num_verts_per_mesh.copy()
         for tex in textures:
             verts_features_list += tex.verts_features_list()
             num_faces_per_mesh += tex._num_verts_per_mesh


### PR DESCRIPTION
Hi,

Nice work! Thank you for this pytorch3d repo which boosted my research efficiency. However, I found a potential unexpected behavior regarding `TextureVertex`. Here is my guess, proposed fixed, and a toy example.

The `TexturesVertex._num_verts_per_mesh` is not correctly copied in `clone()`, `detach()`, `join_batch()`when this property is a list. In fact, it is created as a list as in `__init__` [here](https://github.com/facebookresearch/pytorch3d/blob/master/pytorch3d/renderer/mesh/textures.py#L1255) or [here](https://github.com/facebookresearch/pytorch3d/blob/master/pytorch3d/renderer/mesh/textures.py#L1273)

As a result, when a list of Mehses is join_batched(), the num_verts_per_mesh in the list will be unexpectedly modified although the merged meshes is in correct shape. A toyish self-contained test is as followed:

```
verts, faces = create_cube('cpu', 1)
textures = TexturesVertex(torch.ones_like(verts))
mesh_list = []
for i in range(2):
    meshes = Meshes(verts, faces, textures)
    mesh_list.append(meshes)
for i, each in enumerate(mesh_list):
    print(i, each.textures._num_verts_per_mesh)
# output: 
# 0 [8]
# 1 [8]
joined_meshes = join_meshes_as_batch(mesh_list)
print('joined', joined_meshes.textures._num_verts_per_mesh)
# output: 
# joined [8, 8]
for i, each in enumerate(mesh_list):
    print(i, each.textures._num_verts_per_mesh)
# output: 
0 [8, 8] // !!!!
1 [8, 8] // !!!!
```
Note the output becomes [8, 8] from [8] after join_batch(). After the fixed, the last output is [8] as expected. 

`create_cube` is:
```
def create_cube(device, N=1, align='center'):
    """
    :return: verts: (1, 8, 3) faces: (1, 12, 3)
    """
    cube_verts = torch.tensor(
        [
            [0, 0, 0],
            [0, 0, 1],
            [0, 1, 0],
            [0, 1, 1],
            [1, 0, 0],
            [1, 0, 1],
            [1, 1, 0],
            [1, 1, 1],
        ],
        dtype=torch.float32,
        device=device,
    )
    if align == 'center':
        cube_verts -= .5

    # faces corresponding to a unit cube: 12x3
    cube_faces = torch.tensor(
        [
            [0, 1, 2],
            [1, 3, 2],  # left face: 0, 1
            [2, 3, 6],
            [3, 7, 6],  # bottom face: 2, 3
            [0, 2, 6],
            [0, 6, 4],  # front face: 4, 5
            [0, 5, 1],
            [0, 4, 5],  # up face: 6, 7
            [6, 7, 5],
            [6, 5, 4],  # right face: 8, 9
            [1, 7, 3],
            [1, 5, 7],  # back face: 10, 11
        ],
        dtype=torch.int64,
        device=device,
    )  # 12, 3

    return cube_verts.unsqueeze(0).expand(N, 8, 3), cube_faces.unsqueeze(0).expand(N, 12, 3)
```


