### PR TITLE
Fix: Retain Specific transformations for clone and compose, Fix: inverse returns nan for affine matrix. 

### DIFF
--- a/pytorch3d/transforms/transform3d.py
+++ b/pytorch3d/transforms/transform3d.py
@@ -201,6 +201,7 @@ class Transform3d:
         """
         out = Transform3d(device=self.device)
         out._matrix = self._matrix.clone()
+        out.__class__ = self.__class__
         for other in others:
             if not isinstance(other, Transform3d):
                 msg = "Only possible to compose Transform3d objects; got %s"
@@ -279,11 +280,13 @@ class Transform3d:
                 tinv._transforms = [t.inverse() for t in reversed(self._transforms)]
                 last = Transform3d(device=self.device)
                 last._matrix = i_matrix
+                last.__class__ = self.__class__
                 tinv._transforms.append(last)
             else:
                 # b) Or there are no stored transformations
                 # we just set inverted matrix
                 tinv._matrix = i_matrix
+                tinv.__class__ = self.__class__
 
         return tinv
 
@@ -396,6 +399,7 @@ class Transform3d:
             other._lu = [elem.clone() for elem in self._lu]
         other._matrix = self._matrix.clone()
         other._transforms = [t.clone() for t in self._transforms]
+        other.__class__ = self.__class__
         return other
 
     def to(self, device, copy: bool = False, dtype=None):


### PR DESCRIPTION
I found different behavior of Transform3d.inverse() between CPU and Cuda devices. In particular calling inverse() on an affine transform caused nans sometimes. This is because several methods such as compose and clone output a generic Transform3d, disregarding the specific type they were invoked. For the inverse computation this has several downsides: 
- the fallback, torch.inverse() is used, which is costly
- torch.inverse() can produce nans, even for matrices that in theory are affine, thus have an existing inverse. 

The second point was only observed when computing the inverse on the gpu but not on the cpu. This is explained by the different algorithms that are used for torch.inverse [[source](https://pytorch.org/docs/stable/linalg.html#torch.linalg.inv)]

A minimal example to reproduce:

```python
import torch
import pytorch3d.transforms as transform
import pickle

device = 'cuda:0'

# Test Data (using pickle to get the exact floating point matrixes on which the issue was observed)
last_pose_data = b'\x80\x03cpytorch3d.transforms.transform3d\nTransform3d\nq\x00)\x81q\x01}q\x02(X\x07\x00\x00\x00_matrixq\x03ctorch._utils\n_rebuild_tensor_v2\nq\x04(ctorch.storage\n_load_from_bytes\nq\x05B{\x01\x00\x00\x80\x02\x8a\nl\xfc\x9cF\xf9 j\xa8P\x19.\x80\x02M\xe9\x03.\x80\x02}q\x00(X\x10\x00\x00\x00protocol_versionq\x01M\xe9\x03X\r\x00\x00\x00little_endianq\x02\x88X\n\x00\x00\x00type_sizesq\x03}q\x04(X\x05\x00\x00\x00shortq\x05K\x02X\x03\x00\x00\x00intq\x06K\x04X\x04\x00\x00\x00longq\x07K\x04uu.\x80\x02(X\x07\x00\x00\x00storageq\x00ctorch\nFloatStorage\nq\x01X\x0e\x00\x00\x0094562082141984q\x02X\x03\x00\x00\x00cpuq\x03K Ntq\x04Q.\x80\x02]q\x00X\x0e\x00\x00\x0094562082141984q\x01a. \x00\x00\x00\x00\x00\x00\x00\xdc\x9dC?\xff"%?\x00\x00\x00\x00\x00\x00\x00\x00\xff"%\xbf\xdc\x9dC?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?W\x12??\xfe_*?\x00\x00\x00\x00\x00\x00\x00\x00\xfe_*\xbfW\x12??\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?q\x06\x85q\x07Rq\x08K\x00K\x02K\x04K\x04\x87q\tK\x10K\x04K\x01\x87q\n\x89ccollections\nOrderedDict\nq\x0b)Rq\x0ctq\rRq\x0eX\x0b\x00\x00\x00_transformsq\x0f]q\x10h\x00)\x81q\x11}q\x12(h\x03h\x04(h\x05B{\x01\x00\x00\x80\x02\x8a\nl\xfc\x9cF\xf9 j\xa8P\x19.\x80\x02M\xe9\x03.\x80\x02}q\x00(X\x10\x00\x00\x00protocol_versionq\x01M\xe9\x03X\r\x00\x00\x00little_endianq\x02\x88X\n\x00\x00\x00type_sizesq\x03}q\x04(X\x05\x00\x00\x00shortq\x05K\x02X\x03\x00\x00\x00intq\x06K\x04X\x04\x00\x00\x00longq\x07K\x04uu.\x80\x02(X\x07\x00\x00\x00storageq\x00ctorch\nFloatStorage\nq\x01X\x0e\x00\x00\x0094562077386208q\x02X\x03\x00\x00\x00cpuq\x03K Ntq\x04Q.\x80\x02]q\x00X\x0e\x00\x00\x0094562077386208q\x01a. \x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00&(\xa7?`\xc82?\xc2\x17]?\x00\x00\x80?\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x1d(\xa7?iCJ?\x98f\xa6?\x00\x00\x80?q\x13\x85q\x14Rq\x15K\x00K\x02K\x04K\x04\x87q\x16K\x10K\x04K\x01\x87q\x17\x89h\x0b)Rq\x18tq\x19Rq\x1ah\x0f]q\x1bX\x03\x00\x00\x00_luq\x1cNX\x06\x00\x00\x00deviceq\x1dctorch\ndevice\nq\x1eX\x03\x00\x00\x00cpuq\x1f\x85q Rq!ubah\x1cNh\x1dh\x1eX\x03\x00\x00\x00cpuq"\x85q#Rq$ub.'
last_pose_matrix = pickle.loads(last_pose_data).get_matrix()

print(last_pose_matrix)

pose_data = b'\x80\x03cpytorch3d.transforms.transform3d\nTransform3d\nq\x00)\x81q\x01}q\x02(X\x07\x00\x00\x00_matrixq\x03ctorch._utils\n_rebuild_tensor_v2\nq\x04(ctorch.storage\n_load_from_bytes\nq\x05B{\x01\x00\x00\x80\x02\x8a\nl\xfc\x9cF\xf9 j\xa8P\x19.\x80\x02M\xe9\x03.\x80\x02}q\x00(X\x10\x00\x00\x00protocol_versionq\x01M\xe9\x03X\r\x00\x00\x00little_endianq\x02\x88X\n\x00\x00\x00type_sizesq\x03}q\x04(X\x05\x00\x00\x00shortq\x05K\x02X\x03\x00\x00\x00intq\x06K\x04X\x04\x00\x00\x00longq\x07K\x04uu.\x80\x02(X\x07\x00\x00\x00storageq\x00ctorch\nFloatStorage\nq\x01X\x0e\x00\x00\x0094562076284192q\x02X\x03\x00\x00\x00cpuq\x03K Ntq\x04Q.\x80\x02]q\x00X\x0e\x00\x00\x0094562076284192q\x01a. \x00\x00\x00\x00\x00\x00\x00\x0cWB?\x1f\xa3&?\x00\x00\x00\x00\x00\x00\x00\x00\x1f\xa3&\xbf\x0cWB?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\xa7\xa4=?\xac\xf6+?\x00\x00\x00\x00\x00\x00\x00\x00\xac\xf6+\xbf\xa7\xa4=?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?q\x06\x85q\x07Rq\x08K\x00K\x02K\x04K\x04\x87q\tK\x10K\x04K\x01\x87q\n\x89ccollections\nOrderedDict\nq\x0b)Rq\x0ctq\rRq\x0eX\x0b\x00\x00\x00_transformsq\x0f]q\x10cpytorch3d.transforms.transform3d\nTranslate\nq\x11)\x81q\x12}q\x13(h\x03h\x04(h\x05B{\x01\x00\x00\x80\x02\x8a\nl\xfc\x9cF\xf9 j\xa8P\x19.\x80\x02M\xe9\x03.\x80\x02}q\x00(X\x10\x00\x00\x00protocol_versionq\x01M\xe9\x03X\r\x00\x00\x00little_endianq\x02\x88X\n\x00\x00\x00type_sizesq\x03}q\x04(X\x05\x00\x00\x00shortq\x05K\x02X\x03\x00\x00\x00intq\x06K\x04X\x04\x00\x00\x00longq\x07K\x04uu.\x80\x02(X\x07\x00\x00\x00storageq\x00ctorch\nFloatStorage\nq\x01X\x0e\x00\x00\x0094562076292928q\x02X\x03\x00\x00\x00cpuq\x03K Ntq\x04Q.\x80\x02]q\x00X\x0e\x00\x00\x0094562076292928q\x01a. \x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00L(\xa7?@G7?Z\xc3]?\x00\x00\x80?\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x82(\xa7?\xd2.N?\x11f\xa6?\x00\x00\x80?q\x14\x85q\x15Rq\x16K\x00K\x02K\x04K\x04\x87q\x17K\x10K\x04K\x01\x87q\x18\x89h\x0b)Rq\x19tq\x1aRq\x1bh\x0f]q\x1cX\x03\x00\x00\x00_luq\x1dNX\x06\x00\x00\x00deviceq\x1ectorch\ndevice\nq\x1fX\x03\x00\x00\x00cpuq \x85q!Rq"ubah\x1dNh\x1eh\x1fX\x03\x00\x00\x00cpuq#\x85q$Rq%ub.'
pose_matrix = pickle.loads(pose_data).get_matrix()
print(pose_matrix)

# Global affine transformation from previous time step:
last_rotation = transform.Rotate(R=last_pose_matrix[:,:3,:3], device=device)
last_translation = transform.Translate(last_pose_matrix[:,3,:3], device=device)

last_pose = last_rotation.compose(last_translation).clone()

# Current affine transformation from latest time step:
rotation = transform.Rotate(R=last_pose_matrix[:,:3,:3], device=device)
translation = transform.Translate(last_pose_matrix[:,3,:3], device=device)

pose = rotation.compose(translation)


def compute_relative(last_pose, pose, device):
    lp = last_pose.to(device)
    p = pose.to(device)
    inv = p.inverse()
    return lp.compose(inv)


def traverse_transform(to_traverse, depth=0):
    tabs = depth * '\t'
    print(f"{tabs}{to_traverse.__class__.__name__}")
    for child in to_traverse._transforms:
        traverse_transform(child, depth + 1)
        
        
def has_nan(tensor):
    return torch.isnan(tensor).any().item()

print('\nComposition of last_pose:')
traverse_transform(last_pose)

print('\nComposition of pose:')
traverse_transform(pose)

print('\nComposition of compute_relative(last_pose, pose, device)')
traverse_transform(compute_relative(last_pose, pose, device))

for i in range(10000):
    invalid = has_nan(compute_relative(last_pose, pose, device).get_matrix())
    if invalid:
        print('INVALID')
        break

```

produces the following output:
```bash
tensor([[[ 0.7641,  0.6451,  0.0000,  0.0000],
         [-0.6451,  0.7641,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.6984,  0.8636,  1.0000]],

        [[ 0.7464,  0.6655,  0.0000,  0.0000],
         [-0.6655,  0.7464,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.7901,  1.3000,  1.0000]]])
tensor([[[ 0.7591,  0.6509,  0.0000,  0.0000],
         [-0.6509,  0.7591,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.7159,  0.8663,  1.0000]],

        [[ 0.7408,  0.6717,  0.0000,  0.0000],
         [-0.6717,  0.7408,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.8054,  1.3000,  1.0000]]])

Composition of last_pose:
Transform3d
	Transform3d

Composition of pose:
Transform3d
	Translate

Composition of compute_relative(last_pose, pose, device)
Transform3d
	Transform3d
	Transform3d
		Transform3d
		Transform3d
INVALID

Process finished with exit code 0
```
I.e for a composition of Transformation, Rotation and their inverses Transform3d produces nans. 
With the proposed changes however, the output becomes:

```bash
tensor([[[ 0.7641,  0.6451,  0.0000,  0.0000],
         [-0.6451,  0.7641,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.6984,  0.8636,  1.0000]],

        [[ 0.7464,  0.6655,  0.0000,  0.0000],
         [-0.6655,  0.7464,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.7901,  1.3000,  1.0000]]])
tensor([[[ 0.7591,  0.6509,  0.0000,  0.0000],
         [-0.6509,  0.7591,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.7159,  0.8663,  1.0000]],

        [[ 0.7408,  0.6717,  0.0000,  0.0000],
         [-0.6717,  0.7408,  0.0000,  0.0000],
         [ 0.0000,  0.0000,  1.0000,  0.0000],
         [ 1.3059,  0.8054,  1.3000,  1.0000]]])

Composition of last_pose:
Rotate
	Translate

Composition of pose:
Rotate
	Translate

Composition of compute_relative(last_pose, pose, device)
Rotate
	Translate
	Transform3d
		Translate
		Rotate

Process finished with exit code 0
```

Detailed Changes:
- compose and clone retain the class they are invoked on (no upcast to generic Transform3d).
- inverse retains classes of transform components (no upcast to generic Transform3d).