### PR TITLE
Retain batch dimension if mesh is empty

### DIFF
--- a/pytorch3d/structures/meshes.py
+++ b/pytorch3d/structures/meshes.py
@@ -397,14 +397,6 @@ class Meshes(object):
                        number of verts or faces respectively."
             )
 
-        if self.isempty():
-            self._num_verts_per_mesh = torch.zeros(
-                (0,), dtype=torch.int64, device=self.device
-            )
-            self._num_faces_per_mesh = torch.zeros(
-                (0,), dtype=torch.int64, device=self.device
-            )
-
         # Set the num verts/faces on the textures if present.
         if self.textures is not None:
             self.textures._num_faces_per_mesh = self._num_faces_per_mesh.tolist()


### PR DESCRIPTION
Hi pytorch3d team,

Thank you for your efforts. I really like pytorch3d's heterogeneous batch operations. The feature saves me lots of pains. 

I noticed a corner case when meshes are all empty in each mesh (verts_padded (N, 0, 3)). We currently handle it by setting `_num_verts_per_mesh`/`_num_faces_per_mesh` in both `meshes` and `meshes.texture` to (0,), which is **in shape of (1, )**. By doing this, the batch dimension is disregarded while `meshes._N` is still N. It would lead to [assertion error](https://github.com/facebookresearch/pytorch3d/blob/master/pytorch3d/structures/utils.py#L103-L104) when calling `verts_list()`

I suggest that an arguably desirable behavior would return (0, 0, ....) **in shape of (N, )**, which is more consistent with non-degenerate meshes. The upside is we can then call list <-> padded <-> packed conversions such as `mesehs.verts_list()` without triggering errors. (see test case below). As the `mesh.__init__` is already well written, all we need is to comment out the corner case handler. 



---
minimal test case:

```
import torch
from pytorch3d.structures import Meshes

N = 2
zeros = torch.zeros([N, 0, 3])
meshes = Meshes(zeros, zeros)
print(meshes.verts_list())
print(meshes.verts_packed())
print(meshes.verts_padded())
```

after fix: 
```
[tensor([], size=(0, 3)), tensor([], size=(0, 3))]
tensor([], size=(0, 3))
tensor([], size=(2, 0, 3))
```

before fix: 
```
Traceback (most recent call last):
  File "test_empty_mesh.py", line 16, in <module>
    print(meshes.verts_list())
  File "/private/home/yufeiy2/Tools/pytorch3d/pytorch3d/structures/meshes.py", line 477, in verts_list
    self._verts_padded, self.num_verts_per_mesh().tolist()
  File "/private/home/yufeiy2/Tools/pytorch3d/pytorch3d/structures/utils.py", line 104, in padded_to_list
    raise ValueError("Split size must be of same length as inputs first dimension")
ValueError: Split size must be of same length as inputs first dimension
```