### PR TITLE
NaN (divide by zero) fix for issue #561 and #790

### DIFF
--- a/pytorch3d/csrc/utils/geometry_utils.cuh
+++ b/pytorch3d/csrc/utils/geometry_utils.cuh
@@ -177,7 +177,7 @@ __device__ inline float3 BarycentricPerspectiveCorrectionForward(
   const float w0_top = bary.x * z1 * z2;
   const float w1_top = z0 * bary.y * z2;
   const float w2_top = z0 * z1 * bary.z;
-  const float denom = w0_top + w1_top + w2_top;
+  const float denom = fmaxf(w0_top + w1_top + w2_top, kEpsilon);
   const float w0 = w0_top / denom;
   const float w1 = w1_top / denom;
   const float w2 = w2_top / denom;
@@ -208,7 +208,7 @@ BarycentricPerspectiveCorrectionBackward(
   const float w0_top = bary.x * z1 * z2;
   const float w1_top = z0 * bary.y * z2;
   const float w2_top = z0 * z1 * bary.z;
-  const float denom = w0_top + w1_top + w2_top;
+  const float denom = fmaxf(w0_top + w1_top + w2_top, kEpsilon);
 
   // Now do backward pass
   const float grad_denom_top =


### PR DESCRIPTION
https://github.com/facebookresearch/pytorch3d/issues/561
https://github.com/facebookresearch/pytorch3d/issues/790
Divide by zero fix (NaN fix).  When perspective_correct=True, BarycentricPerspectiveCorrectionForward and BarycentricPerspectiveCorrectionBackward in ../csrc/utils/geometry_utils.cuh are called.  The denominator (denom) values should not be allowed to go to zero. I'm able to resolve this issue locally with this PR and submit it for the team's review.