### PR TITLE
Change rasterize_mesh to return backface indicator

### DIFF
--- a/pytorch3d/csrc/rasterize_meshes/rasterize_meshes.h
+++ b/pytorch3d/csrc/rasterize_meshes/rasterize_meshes.h
@@ -17,7 +17,7 @@
 // *                            FORWARD PASS                                 *
 // ****************************************************************************
 
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 RasterizeMeshesNaiveCpu(
     const torch::Tensor& face_verts,
     const torch::Tensor& mesh_to_face_first_idx,
@@ -31,7 +31,7 @@ RasterizeMeshesNaiveCpu(
     const bool cull_backfaces);
 
 #ifdef WITH_CUDA
-std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor>
+std::tuple<at::Tensor, at::Tensor, at::Tensor, at::Tensor, at::Tensor>
 RasterizeMeshesNaiveCuda(
     const at::Tensor& face_verts,
     const at::Tensor& mesh_to_face_first_idx,
@@ -90,7 +90,7 @@ RasterizeMeshesNaiveCuda(
 //                    viewed from the outside.
 //
 // Returns:
-//    A 4 element tuple of:
+//    A 5 element tuple of:
 //    pix_to_face: int64 tensor of shape (N, H, W, K) giving the face index of
 //                 each of the closest faces to the pixel in the rasterized
 //                 image, or -1 for pixels that are not covered by any face.
@@ -105,7 +105,10 @@ RasterizeMeshesNaiveCuda(
 //           in the (NDC) x/y plane between each pixel and its K closest
 //           faces along the z axis padded  with -1 for pixels hit by fewer than
 //           faces_per_pixel faces.
-inline std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+//    back_faces: bool Tensor of shape (N, H, W, K) giving whether the face is
+//                back-facing torward the camera (True) or front-facing toward
+//                the camera (False). If no face found, default to False.
+inline std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 RasterizeMeshesNaive(
     const torch::Tensor& face_verts,
     const torch::Tensor& mesh_to_face_first_idx,
@@ -322,7 +325,7 @@ torch::Tensor RasterizeMeshesCoarse(
 // ****************************************************************************
 
 #ifdef WITH_CUDA
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 RasterizeMeshesFineCuda(
     const torch::Tensor& face_verts,
     const torch::Tensor& bin_faces,
@@ -377,7 +380,7 @@ RasterizeMeshesFineCuda(
 //                    viewed from the outside.
 //
 // Returns (same as rasterize_meshes):
-//    A 4 element tuple of:
+//    A 5 element tuple of:
 //    pix_to_face: int64 tensor of shape (N, H, W, K) giving the face index of
 //                 each of the closest faces to the pixel in the rasterized
 //                 image, or -1 for pixels that are not covered by any face.
@@ -392,7 +395,10 @@ RasterizeMeshesFineCuda(
 //           in the (NDC) x/y plane between each pixel and its K closest
 //           faces along the z axis padded  with -1 for pixels hit by fewer than
 //           faces_per_pixel faces.
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+//    back_faces: bool Tensor of shape (N, H, W, K) giving whether the face is
+//                back-facing torward the camera (True) or front-facing toward
+//                the camera (False). If no face found, default to False.
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 RasterizeMeshesFine(
     const torch::Tensor& face_verts,
     const torch::Tensor& bin_faces,
@@ -482,7 +488,7 @@ RasterizeMeshesFine(
 //                    viewed from the outside.
 //
 // Returns:
-//    A 4 element tuple of:
+//    A 5 element tuple of:
 //    pix_to_face: int64 tensor of shape (N, H, W, K) giving the face index of
 //                 each of the closest faces to the pixel in the rasterized
 //                 image, or -1 for pixels that are not covered by any face.
@@ -497,7 +503,10 @@ RasterizeMeshesFine(
 //           in the (NDC) x/y plane between each pixel and its K closest
 //           faces along the z axis padded  with -1 for pixels hit by fewer than
 //           faces_per_pixel faces.
-std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
+//    back_faces: bool Tensor of shape (N, H, W, K) giving whether the face is
+//                back-facing torward the camera (True) or front-facing toward
+//                the camera (False). If no face found, default to False.
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor>
 RasterizeMeshes(
     const torch::Tensor& face_verts,
     const torch::Tensor& mesh_to_face_first_idx,

--- a/pytorch3d/ops/sample_points_from_meshes.py
+++ b/pytorch3d/ops/sample_points_from_meshes.py
@@ -129,7 +129,7 @@ def sample_points_from_meshes(
             (len(meshes), num_samples, 1, 1), device=meshes.device, dtype=torch.float32
         )  # NxSx1x1
         fragments = MeshFragments(
-            pix_to_face=pix_to_face, zbuf=dummy, bary_coords=bary, dists=dummy
+            pix_to_face=pix_to_face, zbuf=dummy, bary_coords=bary, dists=dummy, back_faces=dummy
         )
         textures = meshes.sample_textures(fragments)  # NxSx1x1xC
         textures = textures[:, :, 0, 0, :]  # NxSxC

--- a/pytorch3d/renderer/mesh/rasterizer.py
+++ b/pytorch3d/renderer/mesh/rasterizer.py
@@ -19,6 +19,7 @@ class Fragments(NamedTuple):
     zbuf: torch.Tensor
     bary_coords: torch.Tensor
     dists: torch.Tensor
+    back_faces: torch.Tensor
 
 
 @dataclass
@@ -189,7 +190,7 @@ class MeshRasterizer(nn.Module):
                 znear = znear.min().item()
             z_clip = None if not perspective_correct or znear is None else znear / 2
 
-        pix_to_face, zbuf, bary_coords, dists = rasterize_meshes(
+        pix_to_face, zbuf, bary_coords, dists, back_faces = rasterize_meshes(
             meshes_proj,
             image_size=raster_settings.image_size,
             blur_radius=raster_settings.blur_radius,
@@ -203,5 +204,6 @@ class MeshRasterizer(nn.Module):
             cull_to_frustum=raster_settings.cull_to_frustum,
         )
         return Fragments(
-            pix_to_face=pix_to_face, zbuf=zbuf, bary_coords=bary_coords, dists=dists
+            pix_to_face=pix_to_face, zbuf=zbuf, bary_coords=bary_coords, dists=dists,
+            back_faces=back_faces
         )

--- a/tests/bm_barycentric_clipping.py
+++ b/tests/bm_barycentric_clipping.py
@@ -87,6 +87,7 @@ def baryclip_pytorch(
             zbuf=clipped_zbuf,
             dists=fragments.dists,
             pix_to_face=fragments.pix_to_face,
+            back_faces=fragments.back_faces
         )
         torch.cuda.synchronize()
 

--- a/tests/test_blending.py
+++ b/tests/test_blending.py
@@ -174,6 +174,7 @@ class TestBlending(TestCaseMixin, unittest.TestCase):
             bary_coords=bary_coords,
             zbuf=pix_to_face,  # dummy
             dists=pix_to_face,  # dummy
+            back_faces=pix_to_face,   # dummy
         )
         colors = torch.randn((N, H, W, K, 3))
         blend_params = BlendParams(1e-4, 1e-4, (0.5, 0.5, 1))
@@ -211,6 +212,7 @@ class TestBlending(TestCaseMixin, unittest.TestCase):
             pix_to_face=pix_to_face,
             bary_coords=empty,  # dummy
             zbuf=empty,  # dummy
+            back_faces=empty,  # dummy
             dists=dists,
         )
         blend_params = BlendParams(sigma=1e-3)
@@ -248,12 +250,14 @@ class TestBlending(TestCaseMixin, unittest.TestCase):
             pix_to_face=pix_to_face,
             bary_coords=empty,  # dummy
             zbuf=empty,  # dummy
+            back_faces=empty,  # dummy
             dists=dists1,
         )
         fragments2 = Fragments(
             pix_to_face=pix_to_face,
             bary_coords=empty,  # dummy
             zbuf=empty,  # dummy
+            back_faces=empty,  # dummy
             dists=dists2,
         )
 
@@ -303,12 +307,14 @@ class TestBlending(TestCaseMixin, unittest.TestCase):
         fragments1 = Fragments(
             pix_to_face=pix_to_face,
             bary_coords=empty,  # dummy
+            back_faces=empty,  # dummy
             zbuf=zbuf1,
             dists=dists1,
         )
         fragments2 = Fragments(
             pix_to_face=pix_to_face,
             bary_coords=empty,  # dummy
+            back_faces=empty,  # dummy
             zbuf=zbuf2,
             dists=dists2,
         )
@@ -351,6 +357,7 @@ class TestBlending(TestCaseMixin, unittest.TestCase):
             pix_to_face=pix_to_face,
             bary_coords=empty,  # dummy
             zbuf=empty,  # dummy
+            back_faces=empty,  # dummy
             dists=dists1,
         )
         blend_params = BlendParams(sigma=1e-3)
@@ -398,7 +405,7 @@ class TestBlending(TestCaseMixin, unittest.TestCase):
         dists1 = torch.randn(size=(N, S, S, K), requires_grad=True, device=device)
         zbuf = torch.randn(size=(N, S, S, K), requires_grad=True, device=device)
         fragments = Fragments(
-            pix_to_face=pix_to_face, bary_coords=empty, zbuf=zbuf, dists=dists1  # dummy
+            pix_to_face=pix_to_face, bary_coords=empty, zbuf=zbuf, dists=dists1, back_faces=dists1  # dummy
         )
         blend_params = BlendParams(sigma=1e-3)
 

--- a/tests/test_interpolate_face_attributes.py
+++ b/tests/test_interpolate_face_attributes.py
@@ -119,6 +119,7 @@ class TestInterpolateFaceAttributes(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
 
         verts_features_packed = mesh.textures.verts_features_packed()
@@ -148,6 +149,7 @@ class TestInterpolateFaceAttributes(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
         grad_vert_tex = torch.tensor(
             [[0.3, 0.3, 0.3], [0.9, 0.9, 0.9], [0.5, 0.5, 0.5], [0.3, 0.3, 0.3]],
@@ -173,6 +175,7 @@ class TestInterpolateFaceAttributes(TestCaseMixin, unittest.TestCase):
             bary_coords=pix_to_face[..., None].expand(-1, -1, -1, -1, 3),
             zbuf=pix_to_face,
             dists=pix_to_face,
+            back_faces=pix_to_face
         )
         with self.assertRaises(ValueError):
             interpolate_face_attributes(
@@ -186,6 +189,7 @@ class TestInterpolateFaceAttributes(TestCaseMixin, unittest.TestCase):
             bary_coords=pix_to_face,
             zbuf=pix_to_face,
             dists=pix_to_face,
+            back_faces=pix_to_face
         )
         with self.assertRaises(ValueError):
             interpolate_face_attributes(

--- a/tests/test_rasterize_rectangle_images.py
+++ b/tests/test_rasterize_rectangle_images.py
@@ -175,7 +175,7 @@ class TestRasterizeRectangleImagesMeshes(TestCaseMixin, unittest.TestCase):
         Simple wrapper around the rasterize function to return
         the fragment data.
         """
-        face_idxs, zbuf, bary_coords, pix_dists = rasterize_meshes(
+        face_idxs, zbuf, bary_coords, pix_dists, back_faces = rasterize_meshes(
             meshes,
             image_size,
             blur,
@@ -187,6 +187,7 @@ class TestRasterizeRectangleImagesMeshes(TestCaseMixin, unittest.TestCase):
             zbuf=zbuf,
             bary_coords=bary_coords,
             dists=pix_dists,
+            back_faces=back_faces
         )
 
     @staticmethod
@@ -420,7 +421,7 @@ class TestRasterizeRectangleImagesMeshes(TestCaseMixin, unittest.TestCase):
             fragments_naive = self._rasterize(
                 meshes_nonsq_naive, image_size, bin_size=0, blur=blur
             )
-            face_idxs, zbuf, bary_coords, pix_dists = rasterize_meshes_python(
+            face_idxs, zbuf, bary_coords, pix_dists, back_faces = rasterize_meshes_python(
                 meshes_nonsq_python,
                 image_size,
                 blur,
@@ -431,6 +432,7 @@ class TestRasterizeRectangleImagesMeshes(TestCaseMixin, unittest.TestCase):
                 zbuf=zbuf,
                 bary_coords=bary_coords,
                 dists=pix_dists,
+                back_faces=back_faces
             )
 
             # Save debug images if DEBUG is set to true at the top of the file.

--- a/tests/test_render_meshes_clipped.py
+++ b/tests/test_render_meshes_clipped.py
@@ -584,7 +584,7 @@ class TestRenderMeshesClipping(TestCaseMixin, unittest.TestCase):
         cull_backfaces = False
 
         # Rasterize clipped mesh
-        pix_to_face, zbuf, barycentric_coords, dists = _RasterizeFaceVerts.apply(
+        pix_to_face, zbuf, barycentric_coords, dists, back_faces = _RasterizeFaceVerts.apply(
             clipped_faces.face_verts,
             clipped_faces.mesh_to_face_first_idx,
             clipped_faces.num_faces_per_mesh,

--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -73,6 +73,7 @@ class TestShader(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
         shader_classes = [
             HardFlatShader,

--- a/tests/test_texturing.py
+++ b/tests/test_texturing.py
@@ -76,6 +76,7 @@ class TestTexturesVertex(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
         # sample_textures calls interpolate_vertex_colors
         texels = mesh.sample_textures(fragments)
@@ -101,6 +102,7 @@ class TestTexturesVertex(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
         grad_vert_tex = torch.tensor(
             [[0.3, 0.3, 0.3], [0.9, 0.9, 0.9], [0.5, 0.5, 0.5], [0.3, 0.3, 0.3]],
@@ -321,6 +323,7 @@ class TestTexturesAtlas(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
         texels = mesh.textures.sample_textures(fragments)
         self.assertTrue(torch.allclose(texels, expected_vals))
@@ -341,6 +344,7 @@ class TestTexturesAtlas(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=torch.ones_like(pix_to_face),
             dists=torch.ones_like(pix_to_face),
+            back_faces=torch.ones_like(pix_to_face),
         )
         texels = mesh.textures.sample_textures(fragments)
         grad_tex = torch.rand_like(texels)
@@ -557,6 +561,7 @@ class TestTexturesUV(TestCaseMixin, unittest.TestCase):
             bary_coords=barycentric_coords,
             zbuf=pix_to_face,
             dists=pix_to_face,
+            back_faces=pix_to_face,
         )
 
         for align_corners in [True, False]:


### PR DESCRIPTION
This pull request addresses the issue: https://github.com/facebookresearch/pytorch3d/issues/945

In addition to the `pix_to_face, zbuf, bary_coords, dists` returned by `rasterize_meshes`, we additionally return `back_faces` which is a BoolTensor of shape `(N, H, W, num_faces)` that indicates whether the faces is front-facing or back-facing the camera. 