### PR TITLE
Fix scatter_ runtime error: size of index should be smaller than src

### DIFF
--- a/pytorch3d/ops/cubify.py
+++ b/pytorch3d/ops/cubify.py
@@ -224,7 +224,7 @@ def cubify(voxels, thresh, device=None, align: str = "topleft") -> Meshes:
     grid_faces += nyxz[:, 0].view(-1, 1) * num_verts
     idleverts = torch.ones(num_verts * N, dtype=torch.uint8, device=device)
 
-    idleverts.scatter_(0, grid_faces.flatten(), 0)
+    idleverts.scatter_(0, grid_faces.flatten().unique(), 0)
     grid_faces -= nyxz[:, 0].view(-1, 1) * num_verts
     split_size = torch.bincount(nyxz[:, 0], minlength=N)
     faces_list = list(torch.split(grid_faces, split_size.tolist(), 0))


### PR DESCRIPTION
Error Reproduction:

python=3.8.12
pytorch=1.9.1
pytorch3d=0.6.1
cudatoolkit=11.1.74

test.py:
```python
import torch
from pytorch3d.ops import cubify
voxels = torch.Tensor([[[[0,1], [0,0]], [[0,1], [0,0]]]]).float()
meshes = cubify(voxels, 0.5, device="cpu")
```

The error appears when `device="cpu"` and `pytorch=1.9.1` (works fine with pytorch=1.10.2)

Error message:
```console
/home/kyle/anaconda3/envs/adapt-net/lib/python3.8/site-packages/torch/_tensor.py:575: UserWarning: floor_divide is deprecated, and will be removed in a future version of pytorch. It currently rounds toward 0 (like the 'trunc' function NOT 'floor'). This results in incorrect rounding for negative values.
To keep the current behavior, use torch.div(a, b, rounding_mode='trunc'), or for actual floor division, use torch.div(a, b, rounding_mode='floor'). (Triggered internally at  /opt/conda/conda-bld/pytorch_1631630839582/work/aten/src/ATen/native/BinaryOps.cpp:467.)
  return torch.floor_divide(self, other)
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    meshes = cubify(voxels, 0.5, device="cpu")
  File "/home/kyle/anaconda3/envs/adapt-net/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 28, in decorate_context
    return func(*args, **kwargs)
  File "/home/kyle/Desktop/pytorch3d/pytorch3d/ops/cubify.py", line 227, in cubify
    idleverts.scatter_(0, grid_faces.flatten(), 0)
RuntimeError: Expected index [60] to be smaller than self [27] apart from dimension 0 and to be smaller size than src [27]
```