### PR TITLE
R2n2

### DIFF
--- a/pytorch3d/datasets/r2n2/r2n2.py
+++ b/pytorch3d/datasets/r2n2/r2n2.py
@@ -55,9 +55,9 @@ class R2N2(ShapeNetBase):  # pragma: no cover
     def __init__(
         self,
         split: str,
-        shapenet_dir,
-        r2n2_dir,
-        splits_file,
+        shapenet_dir: str,
+        r2n2_dir: str,
+        splits_file: str,
         return_all_views: bool = True,
         return_voxels: bool = False,
         views_rel_path: str = "ShapeNetRendering",
@@ -70,9 +70,9 @@ class R2N2(ShapeNetBase):  # pragma: no cover
 
         Args:
             split (str): One of (train, val, test).
-            shapenet_dir (path): Path to ShapeNet core v1.
-            r2n2_dir (path): Path to the R2N2 dataset.
-            splits_file (path): File containing the train/val/test splits.
+            shapenet_dir (str): Path to ShapeNet core v1.
+            r2n2_dir (str): Path to the R2N2 dataset.
+            splits_file (str): File containing the train/val/test splits.
             return_all_views (bool): Indicator of whether or not to load all the views in
                 the split. If set to False, one of the views in the split will be randomly
                 selected and loaded.

--- a/pytorch3d/datasets/r2n2/utils.py
+++ b/pytorch3d/datasets/r2n2/utils.py
@@ -459,6 +459,12 @@ class BlenderCamera(CamerasBase):  # pragma: no cover
         transform._matrix = self.K.transpose(1, 2).contiguous()
         return transform
 
+    def is_perspective(self):
+        return False
+
+    def in_ndc(self):
+        return True
+
 
 def render_cubified_voxels(
     voxels: torch.Tensor, shader_type=HardPhongShader, device: Device = "cpu", **kwargs


### PR DESCRIPTION
1. Fix #1115 Change the type annatations of three arguments in the initializer of `R2N2` class. 
2. Fix #1118 Override two functions in `BlenderCamera` class reruired by subclassing `CamerasBase` class.