### PR TITLE
numerical instability in compositing.norm_weighted_sum

### DIFF
--- a/pytorch3d/csrc/compositing/norm_weighted_sum.cu
+++ b/pytorch3d/csrc/compositing/norm_weighted_sum.cu
@@ -127,11 +127,7 @@ __global__ void weightedSumNormCudaBackwardKernel(
       sum_alphafs += alphas[batch][k][j][i] * features[ch][n_idx];
     }
 
-    if (sum_alpha > kEpsilon) {
-      sum_alpha_den = kEpsilon;
-    } else {
-      sum_alpha_den = kEpsilon;
-    }
+    sum_alpha_den = max(sum_alpha, kEpsilon);
 
     // Iterate again through the closest K points for this pixel to calculate
     // the gradient.

--- a/pytorch3d/csrc/compositing/norm_weighted_sum_cpu.cpp
+++ b/pytorch3d/csrc/compositing/norm_weighted_sum_cpu.cpp
@@ -114,11 +114,7 @@ std::tuple<torch::Tensor, torch::Tensor> weightedSumNormCpuBackward(
             t_alphafs += alphas_a[b][k][j][i] * features_a[c][n_idx];
           }
 
-          if (t_alpha > kEps) {
-            t_alpha_den = t_alpha;
-          } else {
-            t_alpha_den = kEps;
-          }
+          t_alpha_den = std::max(t_alpha, kEps);
 
           // Iterate through the closest K points for this pixel ordered by z
           // distance.


### PR DESCRIPTION
This PR fixes a numerical instability in `norm_weighted_sum` on `cpu` and `cuda`.

When `points_idx` only contains one point with a small weight (<1e-4) the gradient gets disproportionately large.

Reason:
For numerical stability the normalization scalar (the sum of the weights/alphas) is clipped at `1e-4`. However, this clipping isn't applied to the weighted sum of the features in the numerator.
If the sum of the weights is small the numerator then has a large value which results in an unwanted large gradient.

Fix:
Just clip the normalization scalar for the denominator and not for the numerator.
This also ensures the numerical stability for which the clipping was originally intended.

Code example:


```python
import torch
from pytorch3d.renderer.compositing import norm_weighted_sum

pointsidx = torch.zeros(1, 1, 1, 1, dtype=torch.int64)
alphas = torch.full((1, 1, 1, 1), 1e-10, requires_grad=True)
pt_clds = torch.ones(1, 1)

out = norm_weighted_sum(pointsidx, alphas, pt_clds)
out.sum().backward()
print(f'value:    {out.item()}')
print(f'gradient: {alphas.grad.item()}')
```

Results of current [master](https://github.com/facebookresearch/pytorch3d/commit/cdd2142dd531b4f983468bd9b158f4085ee57dd8):
```
value:    9.999999974752427e-07
gradient: 9999.990234375

```

Results with this branch:
```
value:    9.999999974752427e-07
gradient: 0.0

```