### PR TITLE
shader: add SoftZShader and HardZShader for rendering depth maps

### DIFF
--- a/tests/test_shader.py
+++ b/tests/test_shader.py
@@ -14,7 +14,9 @@ from pytorch3d.renderer.mesh.shader import (
     HardFlatShader,
     HardGouraudShader,
     HardPhongShader,
+    HardZShader,
     SoftPhongShader,
+    SoftZShader,
 )
 from pytorch3d.structures.meshes import Meshes
 
@@ -30,7 +32,9 @@ class TestShader(TestCaseMixin, unittest.TestCase):
             HardFlatShader,
             HardGouraudShader,
             HardPhongShader,
+            HardZShader,
             SoftPhongShader,
+            SoftZShader,
         ]
 
         for shader_class in shader_classes:
@@ -78,7 +82,9 @@ class TestShader(TestCaseMixin, unittest.TestCase):
             HardFlatShader,
             HardGouraudShader,
             HardPhongShader,
+            HardZShader,
             SoftPhongShader,
+            SoftZShader,
         ]
 
         for shader_class in shader_classes:


### PR DESCRIPTION
This adds two shaders for rendering depth maps for meshes. This is useful for structure from motion applications that learn depths based off of camera pair disparities.

There's two shaders, one hard which just returns the distances and then a second that does a cumsum on the probabilities of the points with a weighted sum. Areas that don't have any z faces are set to the zfar distance.

Output from this renderer is `[N, H, W]` since it's just depth no need for channels.

I haven't tested this in an ML model yet just in a notebook.

hard:
![hardzshader](https://user-images.githubusercontent.com/909104/170190363-ef662c97-0bd2-488c-8675-0557a3c7dd06.png)

soft:
![softzshader](https://user-images.githubusercontent.com/909104/170190365-65b08cd7-0c49-4119-803e-d33c1d8c676e.png)
