### PR TITLE
 normalize UV coordinates to [0,1] in make_material_atlas()

### DIFF
--- a/pytorch3d/io/mtl_io.py
+++ b/pytorch3d/io/mtl_io.py
@@ -299,6 +299,7 @@ def make_material_atlas(
 
     # bi-linearly interpolate the textures from the images
     # using the uv coordinates given by uv_pos.
+    uv_pos -= torch.floor(uv_pos)
     textures = _bilinear_interpolation_grid_sample(image, uv_pos)
 
     return textures

--- a/pytorch3d/io/obj_io.py
+++ b/pytorch3d/io/obj_io.py
@@ -77,7 +77,7 @@ def load_obj(
     load_textures: bool = True,
     create_texture_atlas: bool = False,
     texture_atlas_size: int = 4,
-    texture_wrap: Optional[str] = "repeat",
+    texture_wrap: Optional[str] = None,
     device: Device = "cpu",
     path_manager: Optional[PathManager] = None,
 ):


### PR DESCRIPTION
When building a material atlas, it's common to have negative UV coordinates (e.g., Shapenet dataset).
Existing options (texture_wrap="repeat", texture_wrap="clamp", texture_map=None) may fail to produce correct textures.
Failure case 1: texture_wrap = "repeat"
![image](https://user-images.githubusercontent.com/16759292/181136856-c335e6e9-63de-4693-893a-1e37ba86e62e.png)
Failure case 2: texture_wrap = "clamp"
![image](https://user-images.githubusercontent.com/16759292/181136928-b8aeea85-6ec9-44d5-9b62-38501731c998.png)
Failure case 3: texture_wrap = None
![image](https://user-images.githubusercontent.com/16759292/181136979-d17e920a-a088-4fce-bf7f-91211b028490.png)

However, with this commit, using "texture_wrap = None" can produce correct textures for both cases:
![image](https://user-images.githubusercontent.com/16759292/181137053-94db1a77-affa-4712-bce4-fa89f4226db8.png)
![image](https://user-images.githubusercontent.com/16759292/181137069-17fc34a2-bb01-42b5-8016-947f7f2b0dd2.png)