### PR TITLE
[transforms] - fixing runtime error

### DIFF
--- a/pytorch3d/transforms/transform3d.py
+++ b/pytorch3d/transforms/transform3d.py
@@ -343,7 +343,7 @@ class Transform3d:
         points_batch = torch.cat([points_batch, ones], dim=2)
 
         composed_matrix = self.get_matrix()
-        points_out = _broadcast_bmm(points_batch, composed_matrix)
+        points_out = _broadcast_bmm(points_batch, composed_matrix.to(points_batch.dtype))
         denom = points_out[..., 3:]  # denominator
         if eps is not None:
             denom_sign = denom.sign() + (denom == 0.0).type_as(denom)


### PR DESCRIPTION
Line 346 in `pytorch3d/transforms/transform3d`

Raise the error : 
`RuntimeError: Expected object of scalar type Double but got scalar type Float for argument #2 'mat2' in call to _th_bmm_out`

When the parameter `points` of the function `transform_points` has a type (i.e. `float64`). 
In particular when we broadcast `points_batch` to `composed_matrix` with the function `_broadcast_bmm` .

Solved with this fix . Thoughts ?
