### PR TITLE
bugfix: dim=-1 instead of dim=1

### DIFF
--- a/pytorch3d/renderer/cameras.py
+++ b/pytorch3d/renderer/cameras.py
@@ -1626,7 +1626,7 @@ def camera_position_from_spherical_angles(
     x = dist * torch.cos(elev) * torch.sin(azim)
     y = dist * torch.sin(elev)
     z = dist * torch.cos(elev) * torch.cos(azim)
-    camera_position = torch.stack([x, y, z], dim=1)
+    camera_position = torch.stack([x, y, z], dim=-1)
     if camera_position.dim() == 0:
         camera_position = camera_position.view(1, -1)  # add batch dim.
     return camera_position.view(-1, 3)


### PR DESCRIPTION
x,y,z coordinates should always be stacked along the final dimension (dim=-1) instead of dim=1 as is hardcoded now. Otherwise the `return camera_position.view(-1, 3)` will give unexpected results when azimuth/elevation are tensors of dimension 2 or higher (i.e. the last dimension will no longer correspond to x/y/z).

EDIT: I missed the note that inputs should be at most "Torch tensor of shape (N) or (1)" so technically speaking I misused the function by inputting a 2D tensor. Feel free to ignore this PR if you don't find this useful to support more dimensions.