### PR TITLE
Fixing bug in rasterizer.py caused by duplicate line

### DIFF
--- a/pytorch3d/renderer/mesh/rasterizer.py
+++ b/pytorch3d/renderer/mesh/rasterizer.py
@@ -198,9 +198,6 @@ class MeshRasterizer(nn.Module):
         verts_view = cameras.get_world_to_view_transform(**kwargs).transform_points(
             verts_world, eps=eps
         )
-        # Call transform_points instead of explicitly composing transforms to handle
-        # the case, where camera class does not have a projection matrix form.
-        verts_proj = cameras.transform_points(verts_world, eps=eps)
         to_ndc_transform = cameras.get_ndc_camera_transform(**kwargs)
         projection_transform = try_get_projection_transform(cameras, kwargs)
         if projection_transform is not None:


### PR DESCRIPTION
The file [rasterizer.py](https://github.com/facebookresearch/pytorch3d/blob/de3a474d2b9e0f5d4a77c82106a4a8e7853a4e07/pytorch3d/renderer/mesh/rasterizer.py#L201) contains a duplicate line before the check if the projection_transform exists. This causes an exception in the case that a projection transform matrix is already provided. The corresponding lines should be (and are already) in the else case of the if-statement.

Removing these lines fixes the bug and produces the desired behavior.