### PR TITLE
Minor fixes to the Fit Mesh tutorial

### DIFF
--- a/docs/tutorials/deform_source_mesh_to_target_mesh.ipynb
+++ b/docs/tutorials/deform_source_mesh_to_target_mesh.ipynb
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "# Load the dolphin mesh.\n",
-    "trg_obj = os.path.join('dolphin.obj')"
+    "trg_obj = 'dolphin.obj'"
    ]
   },
   {
@@ -247,7 +247,7 @@
     "id": "dYWDl4VGWHRK"
    },
    "source": [
-    "###  Visualize the source and target meshes"
+    "## 2. Visualize the source and target meshes"
    ]
   },
   {
@@ -485,7 +485,7 @@
     "final_verts = final_verts * scale + center\n",
     "\n",
     "# Store the predicted mesh using save_obj\n",
-    "final_obj = os.path.join('./', 'final_model.obj')\n",
+    "final_obj = 'final_model.obj'\n",
     "save_obj(final_obj, final_verts, final_faces)"
    ]
   },
@@ -517,7 +517,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -531,7 +531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/deform_source_mesh_to_target_mesh.ipynb
+++ b/docs/tutorials/deform_source_mesh_to_target_mesh.ipynb
@@ -517,7 +517,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -531,7 +531,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Fix the numbers in the headers. Currently, there are no header number 2, the tutorial jump from 1 to 3.
- Clean some unnecessary code.