### PR TITLE
Updated CircleCI

### DIFF
--- a/.circleci/config.in.yml
+++ b/.circleci/config.in.yml
@@ -17,13 +17,7 @@ setupcuda: &setupcuda
     name: Setup CUDA
     working_directory: ~/
     command: |
-      # download and install nvidia drivers, cuda, etc
-      wget --no-verbose --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run
-      sudo sh ~/nvidia-downloads/cuda_11.3.1_465.19.01_linux.run --silent
-      echo "Done installing CUDA."
-      pyenv versions
-      nvidia-smi
-      pyenv global 3.9.1
+      sudo update-alternatives --set cuda /usr/local/cuda-11.6
 
 binary_common: &binary_common
   parameters:
@@ -61,15 +55,15 @@ binary_common: &binary_common
 jobs:
   main:
     environment:
-      CUDA_VERSION: "11.3"
+      CUDA_VERSION: "11.6"
     resource_class: gpu.nvidia.small.multi
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2023.02.1
     steps:
       - checkout
       - <<: *setupcuda
       - run: pip3 install --progress-bar off imageio wheel matplotlib 'pillow<7'
-      - run: pip3 install --progress-bar off torch==1.10.0+cu113 torchvision==0.11.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+      - run: pip3 install --progress-bar off torch==1.13.1+cu116 torchvision==0.14.1+cu116 -f https://download.pytorch.org/whl/cu116/torch_stable.html
       # - run: conda create -p ~/conda_env python=3.7 numpy
       # - run: conda activate ~/conda_env
       # - run: conda install -c pytorch pytorch torchvision
@@ -79,9 +73,9 @@ jobs:
       - run:
           name: build
           command: |
-            export LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.3/lib64
+            export LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.6/lib64
             python3 setup.py build_ext --inplace
-      - run: LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.3/lib64 python -m unittest discover -v -s tests -t .
+      - run: LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.6/lib64 python -m unittest discover -v -s tests -t .
       - run: python3 setup.py bdist_wheel
 
   binary_linux_wheel:
@@ -128,7 +122,7 @@ jobs:
   binary_linux_conda_cuda:
     <<: *binary_common
     machine:
-      image: ubuntu-1604-cuda-10.2:202012-01
+      image: linux-cuda-11:2023.02.1
     resource_class: gpu.nvidia.small.multi
     steps:
     - checkout
@@ -181,12 +175,6 @@ workflows:
       # - main:
       #     context: DOCKERHUB_TOKEN
       {{workflows()}}
-      - binary_linux_conda_cuda:
-          name: testrun_conda_cuda_py38_cu102_pyt190
-          context: DOCKERHUB_TOKEN
-          python_version: "3.8"
-          pytorch_version: '1.9.0'
-          cu_version: "cu102"
       - binary_macos_wheel:
           cu_version: cpu
           name: macos_wheel_py3.8_cpu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,7 @@ setupcuda: &setupcuda
     name: Setup CUDA
     working_directory: ~/
     command: |
-      # download and install nvidia drivers, cuda, etc
-      wget --no-verbose --no-clobber -P ~/nvidia-downloads https://developer.download.nvidia.com/compute/cuda/11.3.1/local_installers/cuda_11.3.1_465.19.01_linux.run
-      sudo sh ~/nvidia-downloads/cuda_11.3.1_465.19.01_linux.run --silent
-      echo "Done installing CUDA."
-      pyenv versions
-      nvidia-smi
-      pyenv global 3.9.1
+      sudo update-alternatives --set cuda /usr/local/cuda-11.6
 
 binary_common: &binary_common
   parameters:
@@ -61,15 +55,15 @@ binary_common: &binary_common
 jobs:
   main:
     environment:
-      CUDA_VERSION: "11.3"
+      CUDA_VERSION: "11.6"
     resource_class: gpu.nvidia.small.multi
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2204:2023.02.1
     steps:
       - checkout
       - <<: *setupcuda
       - run: pip3 install --progress-bar off imageio wheel matplotlib 'pillow<7'
-      - run: pip3 install --progress-bar off torch==1.10.0+cu113 torchvision==0.11.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
+      - run: pip3 install --progress-bar off torch==1.13.1+cu116 torchvision==0.14.1+cu116 -f https://download.pytorch.org/whl/cu116/torch_stable.html
       # - run: conda create -p ~/conda_env python=3.7 numpy
       # - run: conda activate ~/conda_env
       # - run: conda install -c pytorch pytorch torchvision
@@ -79,9 +73,9 @@ jobs:
       - run:
           name: build
           command: |
-            export LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.3/lib64
+            export LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.6/lib64
             python3 setup.py build_ext --inplace
-      - run: LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.3/lib64 python -m unittest discover -v -s tests -t .
+      - run: LD_LIBRARY_PATH=$LD_LIBARY_PATH:/usr/local/cuda-11.6/lib64 python -m unittest discover -v -s tests -t .
       - run: python3 setup.py bdist_wheel
 
   binary_linux_wheel:
@@ -128,7 +122,7 @@ jobs:
   binary_linux_conda_cuda:
     <<: *binary_common
     machine:
-      image: ubuntu-1604-cuda-10.2:202012-01
+      image: linux-cuda-11:2023.02.1
     resource_class: gpu.nvidia.small.multi
     steps:
     - checkout
@@ -183,121 +177,14 @@ workflows:
       - binary_linux_conda:
           context: DOCKERHUB_TOKEN
           cu_version: cu102
-          name: linux_conda_py38_cu102_pyt190
-          python_version: '3.8'
-          pytorch_version: 1.9.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py38_cu111_pyt190
-          python_version: '3.8'
-          pytorch_version: 1.9.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py38_cu102_pyt191
-          python_version: '3.8'
-          pytorch_version: 1.9.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py38_cu111_pyt191
-          python_version: '3.8'
-          pytorch_version: 1.9.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py38_cu102_pyt1100
-          python_version: '3.8'
-          pytorch_version: 1.10.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py38_cu111_pyt1100
-          python_version: '3.8'
-          pytorch_version: 1.10.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py38_cu113_pyt1100
-          python_version: '3.8'
-          pytorch_version: 1.10.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py38_cu102_pyt1101
-          python_version: '3.8'
-          pytorch_version: 1.10.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py38_cu111_pyt1101
-          python_version: '3.8'
-          pytorch_version: 1.10.1
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py38_cu113_pyt1101
-          python_version: '3.8'
-          pytorch_version: 1.10.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py38_cu102_pyt1102
-          python_version: '3.8'
-          pytorch_version: 1.10.2
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py38_cu111_pyt1102
-          python_version: '3.8'
-          pytorch_version: 1.10.2
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py38_cu113_pyt1102
-          python_version: '3.8'
-          pytorch_version: 1.10.2
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py38_cu102_pyt1110
-          python_version: '3.8'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py38_cu111_pyt1110
-          python_version: '3.8'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py38_cu113_pyt1110
-          python_version: '3.8'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          context: DOCKERHUB_TOKEN
-          cu_version: cu115
-          name: linux_conda_py38_cu115_pyt1110
-          python_version: '3.8'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
           name: linux_conda_py38_cu102_pyt1120
           python_version: '3.8'
           pytorch_version: 1.12.0
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
+          conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py38_cu113_pyt1120
+          cu_version: cu116
+          name: linux_conda_py38_cu116_pyt1120
           python_version: '3.8'
           pytorch_version: 1.12.0
       - binary_linux_conda:
@@ -314,10 +201,10 @@ workflows:
           python_version: '3.8'
           pytorch_version: 1.12.1
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
+          conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py38_cu113_pyt1121
+          cu_version: cu116
+          name: linux_conda_py38_cu116_pyt1121
           python_version: '3.8'
           pytorch_version: 1.12.1
       - binary_linux_conda:
@@ -331,137 +218,30 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
           cu_version: cu116
-          name: linux_conda_py38_cu116_pyt1130
+          name: linux_conda_py38_cu116_pyt1160
           python_version: '3.8'
           pytorch_version: 1.13.0
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda117
           context: DOCKERHUB_TOKEN
           cu_version: cu117
-          name: linux_conda_py38_cu117_pyt1130
+          name: linux_conda_py38_cu117_pyt1160
           python_version: '3.8'
           pytorch_version: 1.13.0
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
           cu_version: cu116
-          name: linux_conda_py38_cu116_pyt1131
+          name: linux_conda_py38_cu116_pyt1161
           python_version: '3.8'
           pytorch_version: 1.13.1
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda117
           context: DOCKERHUB_TOKEN
           cu_version: cu117
-          name: linux_conda_py38_cu117_pyt1131
+          name: linux_conda_py38_cu117_pyt1161
           python_version: '3.8'
           pytorch_version: 1.13.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py39_cu102_pyt190
-          python_version: '3.9'
-          pytorch_version: 1.9.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py39_cu111_pyt190
-          python_version: '3.9'
-          pytorch_version: 1.9.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py39_cu102_pyt191
-          python_version: '3.9'
-          pytorch_version: 1.9.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py39_cu111_pyt191
-          python_version: '3.9'
-          pytorch_version: 1.9.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py39_cu102_pyt1100
-          python_version: '3.9'
-          pytorch_version: 1.10.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py39_cu111_pyt1100
-          python_version: '3.9'
-          pytorch_version: 1.10.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py39_cu113_pyt1100
-          python_version: '3.9'
-          pytorch_version: 1.10.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py39_cu102_pyt1101
-          python_version: '3.9'
-          pytorch_version: 1.10.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py39_cu111_pyt1101
-          python_version: '3.9'
-          pytorch_version: 1.10.1
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py39_cu113_pyt1101
-          python_version: '3.9'
-          pytorch_version: 1.10.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py39_cu102_pyt1102
-          python_version: '3.9'
-          pytorch_version: 1.10.2
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py39_cu111_pyt1102
-          python_version: '3.9'
-          pytorch_version: 1.10.2
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py39_cu113_pyt1102
-          python_version: '3.9'
-          pytorch_version: 1.10.2
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py39_cu102_pyt1110
-          python_version: '3.9'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py39_cu111_pyt1110
-          python_version: '3.9'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py39_cu113_pyt1110
-          python_version: '3.9'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          context: DOCKERHUB_TOKEN
-          cu_version: cu115
-          name: linux_conda_py39_cu115_pyt1110
-          python_version: '3.9'
-          pytorch_version: 1.11.0
       - binary_linux_conda:
           context: DOCKERHUB_TOKEN
           cu_version: cu102
@@ -469,10 +249,10 @@ workflows:
           python_version: '3.9'
           pytorch_version: 1.12.0
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
+          conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py39_cu113_pyt1120
+          cu_version: cu116
+          name: linux_conda_py39_cu116_pyt1120
           python_version: '3.9'
           pytorch_version: 1.12.0
       - binary_linux_conda:
@@ -489,10 +269,10 @@ workflows:
           python_version: '3.9'
           pytorch_version: 1.12.1
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
+          conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py39_cu113_pyt1121
+          cu_version: cu116
+          name: linux_conda_py39_cu116_pyt1121
           python_version: '3.9'
           pytorch_version: 1.12.1
       - binary_linux_conda:
@@ -506,56 +286,30 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
           cu_version: cu116
-          name: linux_conda_py39_cu116_pyt1130
+          name: linux_conda_py39_cu116_pyt1160
           python_version: '3.9'
           pytorch_version: 1.13.0
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda117
           context: DOCKERHUB_TOKEN
           cu_version: cu117
-          name: linux_conda_py39_cu117_pyt1130
+          name: linux_conda_py39_cu117_pyt1160
           python_version: '3.9'
           pytorch_version: 1.13.0
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
           cu_version: cu116
-          name: linux_conda_py39_cu116_pyt1131
+          name: linux_conda_py39_cu116_pyt1161
           python_version: '3.9'
           pytorch_version: 1.13.1
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda117
           context: DOCKERHUB_TOKEN
           cu_version: cu117
-          name: linux_conda_py39_cu117_pyt1131
+          name: linux_conda_py39_cu117_pyt1161
           python_version: '3.9'
           pytorch_version: 1.13.1
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu102
-          name: linux_conda_py310_cu102_pyt1110
-          python_version: '3.10'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          context: DOCKERHUB_TOKEN
-          cu_version: cu111
-          name: linux_conda_py310_cu111_pyt1110
-          python_version: '3.10'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
-          context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py310_cu113_pyt1110
-          python_version: '3.10'
-          pytorch_version: 1.11.0
-      - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda115
-          context: DOCKERHUB_TOKEN
-          cu_version: cu115
-          name: linux_conda_py310_cu115_pyt1110
-          python_version: '3.10'
-          pytorch_version: 1.11.0
       - binary_linux_conda:
           context: DOCKERHUB_TOKEN
           cu_version: cu102
@@ -563,10 +317,10 @@ workflows:
           python_version: '3.10'
           pytorch_version: 1.12.0
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
+          conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py310_cu113_pyt1120
+          cu_version: cu116
+          name: linux_conda_py310_cu116_pyt1120
           python_version: '3.10'
           pytorch_version: 1.12.0
       - binary_linux_conda:
@@ -583,10 +337,10 @@ workflows:
           python_version: '3.10'
           pytorch_version: 1.12.1
       - binary_linux_conda:
-          conda_docker_image: pytorch/conda-builder:cuda113
+          conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
-          cu_version: cu113
-          name: linux_conda_py310_cu113_pyt1121
+          cu_version: cu116
+          name: linux_conda_py310_cu116_pyt1121
           python_version: '3.10'
           pytorch_version: 1.12.1
       - binary_linux_conda:
@@ -600,28 +354,28 @@ workflows:
           conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
           cu_version: cu116
-          name: linux_conda_py310_cu116_pyt1130
+          name: linux_conda_py310_cu116_pyt1160
           python_version: '3.10'
           pytorch_version: 1.13.0
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda117
           context: DOCKERHUB_TOKEN
           cu_version: cu117
-          name: linux_conda_py310_cu117_pyt1130
+          name: linux_conda_py310_cu117_pyt1160
           python_version: '3.10'
           pytorch_version: 1.13.0
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda116
           context: DOCKERHUB_TOKEN
           cu_version: cu116
-          name: linux_conda_py310_cu116_pyt1131
+          name: linux_conda_py310_cu116_pyt1161
           python_version: '3.10'
           pytorch_version: 1.13.1
       - binary_linux_conda:
           conda_docker_image: pytorch/conda-builder:cuda117
           context: DOCKERHUB_TOKEN
           cu_version: cu117
-          name: linux_conda_py310_cu117_pyt1131
+          name: linux_conda_py310_cu117_pyt1161
           python_version: '3.10'
           pytorch_version: 1.13.1
       - binary_linux_conda_cuda:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,31 @@
+name: CI
+on: [push, pull_request]
+
+# Run linter with github actions for quick feedbacks.
+# Run macos tests with github actions. Linux (CPU & GPU) tests currently runs on CircleCI
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    # run on PRs, or commits to facebookresearch (not internal)
+    if: ${{ github.repository_owner == 'facebookresearch' || github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+      - name: Install dependencies
+        # flake8-bugbear flake8-comprehensions are useful but not available internally
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install flake8==6.0.0 isort==5.12.0
+          python -m pip install black==23.1.0
+          flake8 --version
+      - name: Lint
+        run: |
+          echo "Running isort"
+          isort -c -sp .
+          echo "Running black"
+          black -l 88 --check .
+          echo "Running flake8"
+          flake8 .


### PR DESCRIPTION
- [X] Python <3.9 versions deleted (Deprecated 27 Jun 2023)
- [X] Python 3.10.6 (added as default) (CircleCI images have 3.10.6)
- [x] Pytorch <1.12 delete. Deprecated (https://pytorch.org/blog/deprecation-cuda-python-support/)
- [X] Updated ubuntu-2204:2023.02.1 CPU
- [X] Updated linux-cuda-11:2023.02.1 GPU https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/3
- [X] New image circleCI Cuda 11.8 and they are working to CUDA 12. https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/4
- [X] Updated test compatible with CUDA and Pytorch > 1.12
- [X] Unified workflow github and CircleCI python versions: Python 3.10.6
- [X] Ready For Pytorch 2.0 and CUDA 12.0/12.1 CircleCI(CircleCI working on release cuda 12 images at the end of the month)