### PR TITLE
fix: add torch as build system requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "pytorch3d"
+authors = [{ name = "FAIR" }]
+dependencies = ["iopath", "fvcore"]
+description = "PyTorch3D is FAIR's library of reusable components for deep Learning with 3D data."
+dynamic = ["version"]
+requires-python = ">=3.8,<3.11"
+
+[project.optional-dependencies]
+all = ["imageio", "ipywidgets", "matplotlib", "tqdm>4.29.0"]
+dev = ["flake8", "usort"]
+implicitron = [
+    "accelerate",
+    "hydra-core>=1.1",
+    "lpips",
+    "matplotlib",
+    "tqdm>4.29.0",
+    "visdom",
+]
+
+[build-system]
+requires = ["setuptools", "torch >1.9, <=1.14"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.dynamic]
+version = { attr = "pytorch3d.__version__" }

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@
 
 import glob
 import os
-import runpy
 import sys
 import warnings
 from typing import List, Optional
@@ -126,10 +125,6 @@ def get_extensions():
     return ext_modules
 
 
-# Retrieve __version__ from the package.
-__version__ = runpy.run_path("pytorch3d/__init__.py")["__version__"]
-
-
 if os.getenv("PYTORCH3D_NO_NINJA", "0") == "1":
 
     class BuildExtension(torch.utils.cpp_extension.BuildExtension):
@@ -142,30 +137,12 @@ else:
 trainer = "pytorch3d.implicitron_trainer"
 
 setup(
-    name="pytorch3d",
-    version=__version__,
-    author="FAIR",
     url="https://github.com/facebookresearch/pytorch3d",
-    description="PyTorch3D is FAIR's library of reusable components "
-    "for deep Learning with 3D data.",
     packages=find_packages(
         exclude=("configs", "tests", "tests.*", "docs.*", "projects.*")
     )
     + [trainer],
     package_dir={trainer: "projects/implicitron_trainer"},
-    install_requires=["fvcore", "iopath"],
-    extras_require={
-        "all": ["matplotlib", "tqdm>4.29.0", "imageio", "ipywidgets"],
-        "dev": ["flake8", "usort"],
-        "implicitron": [
-            "hydra-core>=1.1",
-            "visdom",
-            "lpips",
-            "tqdm>4.29.0",
-            "matplotlib",
-            "accelerate",
-        ],
-    },
     entry_points={
         "console_scripts": [
             f"pytorch3d_implicitron_runner={trainer}.experiment:experiment",


### PR DESCRIPTION
## What?

I've added a new `pyproject.toml` file to the project that contains static information according to PEP 517.

I've also added `torch` as build system requirement so that isolated installation via `setuptools` (and also `poetry` and probably most other PEP 517 compliant build frontends) works.

## Tests?

I've tested this via

```sh
pip install --isolated --verbose --editable .
```

from within the project directory (and via `poetry` when I provide this project as path dependency).

## Anything else?

I should also say that I have no clue about any other specifics that might make the installation or packaging fail and just did this to solve my current problem of integrating `pytorch3d` into `poetry`. Anyway, I'm also interested in getting your feedback on this..

WDYT?