### PR TITLE
1-line tutorial notebook plotting change to fix blank figure problem

### DIFF
--- a/docs/tutorials/deform_source_mesh_to_target_mesh.ipynb
+++ b/docs/tutorials/deform_source_mesh_to_target_mesh.ipynb
@@ -262,7 +262,7 @@
     "    points = sample_points_from_meshes(mesh, 5000)\n",
     "    x, y, z = points.clone().detach().cpu().squeeze().unbind(1)    \n",
     "    fig = plt.figure(figsize=(5, 5))\n",
-    "    ax = Axes3D(fig)\n",
+    "    ax = fig.add_subplot(111, projection='3d')\n",
     "    ax.scatter3D(x, z, -y)\n",
     "    ax.set_xlabel('x')\n",
     "    ax.set_ylabel('z')\n",


### PR DESCRIPTION
Hi, 

Not sure this is the best fix. But while running this notebook, I only ever saw a blank canvas when trying to visualize the dolphin. It might be that I have a broken dependency, like plotly. I also don't know what the visualization is "supposed" to look like.

But incase other people have this issue, this one line change solved the whole problem for me. Now I have a happy, rotatable dolphin.