### PR TITLE
adds join_pointclouds_as_batch() in __init__.py  for v0.7.2

### DIFF
--- a/pytorch3d/structures/__init__.py
+++ b/pytorch3d/structures/__init__.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from .meshes import join_meshes_as_batch, join_meshes_as_scene, Meshes
-from .pointclouds import Pointclouds
+from .pointclouds import Pointclouds, join_pointclouds_as_batch
 from .utils import list_to_packed, list_to_padded, packed_to_list, padded_to_list
 from .volumes import Volumes
 


### PR DESCRIPTION
Those who are using the `pytorch3d==0.7.2` with `CUDA==11.3` and `torch==1.12.1`, can't import `join_pointclouds_as_batch` even though the function is defined in `pytorch3d.structures.pointclouds`. 
So instead of manually editing the code, it's better to update the released version `v0.7.2`, with this update.

So that others can install it using `pip`