### PR TITLE
Fix poetry lock fails

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     import subprocess
     import sys
+
     if subprocess.call([sys.executable, "-m", "pip", "install", "torch"]) != 0:
         raise RuntimeError("PyTorch not found. Install PyTorch to install PyTorch3D.")
     else:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,15 @@ import sys
 import warnings
 from typing import List, Optional
 
-import torch
+try:
+    import torch
+except ImportError:
+    import subprocess
+    import sys
+    if subprocess.call([sys.executable, "-m", "pip", "install", "torch"]) != 0:
+        raise RuntimeError("PyTorch not found. Install PyTorch to install PyTorch3D.")
+    else:
+        import torch
 from setuptools import find_packages, setup
 from torch.utils.cpp_extension import CppExtension, CUDA_HOME, CUDAExtension
 


### PR DESCRIPTION
Poetry lock fails with pytorch3d as dependency because the resolver runs in a dedicated, clean venv on every run. Therefore, `import torch` fails in pytorch3d's `setup.py` and we need to install it while resolving dependencies.

I believe this is a bug that anyone using poetry would have when specifying pytorch3d as a dependency in their `pyproject.toml` file - at least when installing directly from source.