### PR TITLE
feat: adjusted sample_nums

### DIFF
--- a/docs/tutorials/dataloaders_ShapeNetCore_R2N2.ipynb
+++ b/docs/tutorials/dataloaders_ShapeNetCore_R2N2.ipynb
@@ -411,7 +411,7 @@
    "outputs": [],
    "source": [
     "random_model_images = shapenet_dataset.render(\n",
-    "    sample_nums=[3],\n",
+    "    sample_nums=[5],\n",
     "    device=device,\n",
     "    cameras=cameras,\n",
     "    raster_settings=raster_settings,\n",


### PR DESCRIPTION
adjusted sample_nums to match the number of columns in the image grid. It originally produced image grid with 5 axes but only 3 images and after this fix, the block would work as intended.