### PR TITLE
Fix _add_camera_trace in plotly_vis.py

### DIFF
--- a/pytorch3d/vis/plotly_vis.py
+++ b/pytorch3d/vis/plotly_vis.py
@@ -783,7 +783,7 @@ def _add_camera_trace(
         camera_scale: the size of the wireframe used to render the Cameras object.
     """
     cam_wires = get_camera_wireframe(camera_scale).to(cameras.device)
-    cam_trans = cameras.get_world_to_view_transform().inverse()
+    cam_trans = cameras.get_world_to_view_transform()
     cam_wires_trans = cam_trans.transform_points(cam_wires).detach().cpu()
     # if batch size is 1, unsqueeze to add dimension
     if len(cam_wires_trans.shape) < 3:


### PR DESCRIPTION
For `cam_trans`, the `inverse()` is not appropriate for the camera position visualization.