### PR TITLE
feat: changed = to ==

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -21,7 +21,7 @@ The runtime dependencies can be installed by running:
 ```
 conda create -n pytorch3d python=3.9
 conda activate pytorch3d
-conda install pytorch=1.13.0 torchvision pytorch-cuda=11.6 -c pytorch -c nvidia
+conda install pytorch==1.13.0 torchvision pytorch-cuda==11.6 -c pytorch -c nvidia
 conda install -c fvcore -c iopath -c conda-forge fvcore iopath
 ```
 


### PR DESCRIPTION
The official pytorch's documentation follows the following notation with == instead of =.

https://pytorch.org/get-started/previous-versions/

consistency changes.