### PR TITLE
convert circleci workflows to github actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,176 @@
+name: facebookresearch/pytorch3d/build_and_test
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  binary_linux_conda:
+    runs-on: 4-core-ubuntu-gpu-t4
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        pytorch_version: ["1.12.0", "1.12.1", "1.13.0", "1.13.1", "2.0.0", "2.0.1", "2.1.0", "2.1.1", "2.1.2", "2.2.0"]
+        cu_version: ["113", "116", "117", "118", "121"]
+        exclude:
+          # exclude pytorch 1.12.0 and cu [117, 118, 121]
+          - pytorch_version: "1.12.0"
+            cu_version: "117"
+          - pytorch_version: "1.12.0"
+            cu_version: "118"
+          - pytorch_version: "1.12.0"
+            cu_version: "121"
+          # exclude pytorch 1.12.1 and cu [117, 118, 121]
+          - pytorch_version: "1.12.1"
+            cu_version: "117"
+          - pytorch_version: "1.12.1"
+            cu_version: "118"
+          - pytorch_version: "1.12.1"
+            cu_version: "121"
+          # exclude pytorch 1.13.0 and cu [113, 118, 121]
+          - pytorch_version: "1.13.0"
+            cu_version: "113"
+          - pytorch_version: "1.13.0"
+            cu_version: "118"
+          - pytorch_version: "1.13.0"
+            cu_version: "121"
+          # exclude pytorch 1.13.1 and cu [113, 118, 121]
+          - pytorch_version: "1.13.1"
+            cu_version: "113"
+          - pytorch_version: "1.13.1"
+            cu_version: "118"
+          - pytorch_version: "1.13.1"
+            cu_version: "121"
+          # exclude pytorch 2.0.0 and cu [113, 116, 121]
+          - pytorch_version: "2.0.0"
+            cu_version: "113"
+          - pytorch_version: "2.0.0"
+            cu_version: "116"
+          - pytorch_version: "2.0.0"
+            cu_version: "121"
+          # exclude pytorch 2.0.1 and cu [113, 116, 121]
+          - pytorch_version: "2.0.1"
+            cu_version: "113"
+          - pytorch_version: "2.0.1"
+            cu_version: "116"
+          - pytorch_version: "2.0.1"
+            cu_version: "121"
+          # exclude pytorch 2.1.0 and cu [113, 116, 117]
+          - pytorch_version: "2.1.0"
+            cu_version: "113"
+          - pytorch_version: "2.1.0"
+            cu_version: "116"
+          - pytorch_version: "2.1.0"
+            cu_version: "117"
+          # exclude pytorch 2.1.1 and cu [113, 116, 117]
+          - pytorch_version: "2.1.1"
+            cu_version: "113"
+          - pytorch_version: "2.1.1"
+            cu_version: "116"
+          - pytorch_version: "2.1.1"
+            cu_version: "117"
+          # exclude pytorch 2.1.2 and cu [113, 116, 117]
+          - pytorch_version: "2.1.2"
+            cu_version: "113"
+          - pytorch_version: "2.1.2"
+            cu_version: "116"
+          - pytorch_version: "2.1.2"
+            cu_version: "117"
+          # exclude pytorch 2.2.0 and cu [113, 116, 117]
+          - pytorch_version: "2.2.0"
+            cu_version: "113"
+          - pytorch_version: "2.2.0"
+            cu_version: "116"
+          - pytorch_version: "2.2.0"
+            cu_version: "117"
+          # exlcude python 3.11 and cu [113, 116, 117]
+          - python_version: "3.11"
+            cu_version: "113"
+          - python_version: "3.11"
+            cu_version: "116"
+          - python_version: "3.11"
+            cu_version: "117"
+          # exclude python 3.11 and pytorch [1.12.0, 1.12.1, 1.13.0, 1.3.1, 2.0.0, 2.0.1]
+          - python_version: "3.11"
+            pytorch_version: "1.12.0"
+          - python_version: "3.11"
+            pytorch_version: "1.12.1"
+          - python_version: "3.11"
+            pytorch_version: "1.13.0"
+          - python_version: "3.11"
+            pytorch_version: "1.13.1"
+          - python_version: "3.11"
+            pytorch_version: "2.0.0"
+          - python_version: "3.11"
+            pytorch_version: "2.0.1"
+          # exlcude python 3.12 and cu [113, 116, 117]
+          - python_version: "3.12"
+            cu_version: "113"
+          - python_version: "3.12"
+            cu_version: "116"
+          - python_version: "3.12"
+            cu_version: "117"
+          # exclude python 3.11 and pytorch [1.12.0, 1.12.1, 1.13.0, 1.3.1, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.1.2]
+          - python_version: "3.12"
+            pytorch_version: "1.12.0"
+          - python_version: "3.12"
+            pytorch_version: "1.12.1"
+          - python_version: "3.12"
+            pytorch_version: "1.13.0"
+          - python_version: "3.12"
+            pytorch_version: "1.13.1"
+          - python_version: "3.12"
+            pytorch_version: "2.0.0"
+          - python_version: "3.12"
+            pytorch_version: "2.0.1"
+          - python_version: "3.12"
+            pytorch_version: "2.1.0"
+          - python_version: "3.12"
+            pytorch_version: "2.1.1"
+          - python_version: "3.12"
+            pytorch_version: "2.1.2"
+    container:
+      image: pytorch/conda-builder:cuda${{ matrix.cu_version }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    env:
+      PYTHON_VERSION: "${{ matrix.python_version }}"
+      BUILD_VERSION: "${{ github.run_number }}"
+      PYTORCH_VERSION: "${{ matrix.pytorch_version }}"
+      CU_VERSION: "cu${{ matrix.cu_version }}"
+      TESTRUN_DOCKER_IMAGE: "pytorch/conda-builder:cuda${{ matrix.cu_version }}"
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: build
+      run: MAX_JOBS=15 TEST_FLAG=--no-test python3 packaging/build_conda.py
+    - uses: actions/upload-artifact@v3
+      with:
+        path: "/opt/conda/conda-bld/linux-64"
+  binary_linux_conda_cuda:
+    runs-on: 4-core-ubuntu-gpu-t4
+    container:
+      image: pytorch/conda-cuda
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    env:
+      PYTHON_VERSION: "3.10"
+      BUILD_VERSION: "${{ github.run_number }}"
+      PYTORCH_VERSION: "2.0.1"
+      CU_VERSION: "cu117"
+      TESTRUN_DOCKER_IMAGE: "pytorch/conda-cuda"
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      JUST_TESTRUN: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build and run tests
+      run: |-
+        # set -e
+        # export JUST_TESTRUN=1
+        # VARS_TO_PASS="-e PYTHON_VERSION -e BUILD_VERSION -e PYTORCH_VERSION -e CU_VERSION -e JUST_TESTRUN"
+        # docker run --gpus all  --ipc=host -v $(pwd):/remote -w /remote ${VARS_TO_PASS} ${TESTRUN_DOCKER_IMAGE} python3 ./packaging/build_conda.py
+        python3 ./packaging/build_conda.py


### PR DESCRIPTION
This pull request converts the CircleCI workflows to GitHub actions workflows.  

## Notes
[GPU runners](https://github.blog/changelog/2023-10-31-run-your-ml-workloads-on-github-actions-with-gpu-runners/) are needed with the label `4-core-ubuntu-gpu-t4`.

Two repo secrets are needed for docker hub authentication:
```
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
```

Most of the jobs run via a [matrix](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) consisting of `python_version`, `pytorch_version`, and `cu_version`. There are many `exclude` entries to limit combinations to only those that are run the circleci. As is, if one job in the matrix fails, the remaining jobs will be cancelled. This is probably desireable given these jobs run on expensive [GPU runners](https://github.blog/changelog/2023-10-31-run-your-ml-workloads-on-github-actions-with-gpu-runners/). This behavior can be changed to allow jobs to complete regardless of some job failures. See [handling failures](https://github.blog/changelog/2023-10-31-run-your-ml-workloads-on-github-actions-with-gpu-runners/) for more information.  

The `binary_linux_conda_cuda` in circleci pulls a docker image, then starts that docker image and runs tests inside of it. I didn't really see the point of this, so I chose to just simply run the tests inside the docker image.  

## Errors
I did my best to make all the jobs work, but lacking knowledge specific to this project makes it nearly impossible for me to get everything working. Someone with better knowledge of this project will need to address these error.  

The following jobs fail with errors:  

[binary_linux_conda (3.8, 1.12.0, 113)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841815571)  
[binary_linux_conda (3.8, 1.12.0, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841815816)  
[binary_linux_conda (3.8, 1.12.1, 113)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841816057)  
[binary_linux_conda (3.8, 1.12.1, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841819891)  
[binary_linux_conda (3.8, 1.13.0, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841820293)  
[binary_linux_conda (3.8, 1.13.0, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841820624)  
[binary_linux_conda (3.8, 1.13.1, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841822021)  
[binary_linux_conda (3.8, 1.13.1, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841822275)  
[binary_linux_conda (3.8, 2.0.0, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841822543)  
[binary_linux_conda (3.8, 2.0.0, 118)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841822766)  
[binary_linux_conda (3.8, 2.0.1, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841823019)  
[binary_linux_conda (3.8, 2.0.1, 118)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841823227)  
[binary_linux_conda (3.9, 1.12.0, 113)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841825475)  
[binary_linux_conda (3.9, 1.12.0, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841825687)  
[binary_linux_conda (3.9, 1.12.1, 113)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841825901)  
[binary_linux_conda (3.9, 1.12.1, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841826100)  
[binary_linux_conda (3.9, 1.13.0, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841826345)  
[binary_linux_conda (3.9, 1.13.0, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841826552)  
[binary_linux_conda (3.9, 1.13.1, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841826747)  
[binary_linux_conda (3.9, 1.13.1, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841826996)  
[binary_linux_conda (3.9, 2.0.0, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841827214)  
[binary_linux_conda (3.9, 2.0.0, 118)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841827516)  
[binary_linux_conda (3.9, 2.0.1, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841827867)  
[binary_linux_conda (3.9, 2.0.1, 118)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841828164)  
[binary_linux_conda (3.10, 1.12.0, 113)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841830487)  
[binary_linux_conda (3.10, 1.12.0, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841830751)  
[binary_linux_conda (3.10, 1.12.1, 113)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841830969)  
[binary_linux_conda (3.10, 1.12.1, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841831253)  
[binary_linux_conda (3.10, 1.13.0, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841831572)  
[binary_linux_conda (3.10, 1.13.0, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841831857)  
[binary_linux_conda (3.10, 1.13.1, 116)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841832099)  
[binary_linux_conda (3.10, 1.13.1, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841832378)  
[binary_linux_conda (3.10, 2.0.0, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841832678)  
[binary_linux_conda (3.10, 2.0.0, 118)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841832983)  
[binary_linux_conda (3.10, 2.0.1, 117)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841833293)  
[binary_linux_conda (3.10, 2.0.1, 118)](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753/job/23841833554)  

<details><summary>binary_linux_conda_cuda</summary>
This job exceeds the 6 hour job execution time limit. See <a href="https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits">usage limits</a> for more details.

```
Error: The operation was canceled.
```

</details>

---
[Here is the latest workflow run in my fork](https://github.com/robandpdx-org/pytorch3d/actions/runs/8693940753).  

---
https://fburl.com/workplace/f6mz6tmw