### PR TITLE
Allow indexing for classes inheriting Transform3d

### DIFF
--- a/pytorch3d/transforms/transform3d.py
+++ b/pytorch3d/transforms/transform3d.py
@@ -198,7 +198,9 @@ class Transform3d:
         """
         if isinstance(index, int):
             index = [index]
-        return self.__class__(matrix=self.get_matrix()[index])
+        instance = self.__class__.__new__(self.__class__)
+        instance._matrix = self.get_matrix()[index]
+        return instance
 
     def compose(self, *others: "Transform3d") -> "Transform3d":
         """

--- a/pytorch3d/transforms/transform3d.py
+++ b/pytorch3d/transforms/transform3d.py
@@ -200,6 +200,8 @@ class Transform3d:
             index = [index]
         instance = self.__class__.__new__(self.__class__)
         instance._matrix = self.get_matrix()[index]
+        for attr in ('_transforms', '_lu', 'device', 'dtype'):
+            setattr(instance, attr, getattr(self, attr))
         return instance
 
     def compose(self, *others: "Transform3d") -> "Transform3d":

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -685,6 +685,15 @@ class TestTranslate(unittest.TestCase):
         self.assertTrue(torch.allclose(im, im_comp))
         self.assertTrue(torch.allclose(im, im_2))
 
+    def test_get_item(self, batch_size=5):
+        device = torch.device("cuda:0")
+        xyz = torch.randn(size=[batch_size, 3], device=device, dtype=torch.float32)
+        t3d = Translate(xyz)
+        index = 1
+        t3d_selected = t3d[index]
+        self.assertEqual(len(t3d_selected), 1)
+        self.assertIsInstance(t3d_selected, Translate)
+
 
 class TestScale(unittest.TestCase):
     def test_single_python_scalar(self):
@@ -871,6 +880,15 @@ class TestScale(unittest.TestCase):
         self.assertTrue(torch.allclose(im, im_comp))
         self.assertTrue(torch.allclose(im, im_2))
 
+    def test_get_item(self, batch_size=5):
+        device = torch.device("cuda:0")
+        s = torch.randn(size=[batch_size, 3], device=device, dtype=torch.float32)
+        t3d = Scale(s)
+        index = 1
+        t3d_selected = t3d[index]
+        self.assertEqual(len(t3d_selected), 1)
+        self.assertIsInstance(t3d_selected, Scale)
+
 
 class TestTransformBroadcast(unittest.TestCase):
     def test_broadcast_transform_points(self):
@@ -985,6 +1003,15 @@ class TestRotate(unittest.TestCase):
         im_comp = t.get_matrix().inverse()
         self.assertTrue(torch.allclose(im, im_comp, atol=1e-4))
         self.assertTrue(torch.allclose(im, im_2, atol=1e-4))
+
+    def test_get_item(self, batch_size=5):
+        device = torch.device("cuda:0")
+        r = random_rotations(batch_size, dtype=torch.float32, device=device)
+        t3d = Rotate(r)
+        index = 1
+        t3d_selected = t3d[index]
+        self.assertEqual(len(t3d_selected), 1)
+        self.assertIsInstance(t3d_selected, Rotate)
 
 
 class TestRotateAxisAngle(unittest.TestCase):


### PR DESCRIPTION
Currently, it is not possible to access a sub-transform using an indexer for all 3d transforms inheriting the `Transforms3d` class.
For instance:

```python
from pytorch3d import transforms

N = 10
r = transforms.random_rotations(N)
T = transforms.Transform3d().rotate(R=r)
R = transforms.Rotate(r)

x = T[0]  # ok
x = R[0]  # TypeError: __init__() got an unexpected keyword argument 'matrix'
```

This is because all these classes (namely `Rotate`, `Translate`, `Scale`, `RotateAxisAngle`) inherit the `__getitem__()` method from `Transform3d` which has the [following code on line 201](https://github.com/facebookresearch/pytorch3d/blob/main/pytorch3d/transforms/transform3d.py#L201):

```python
return self.__class__(matrix=self.get_matrix()[index])
```

The four classes inheriting `Transform3d` are not initialized through a matrix argument, hence they error.
I propose to modify the `__getitem__()` method of the `Transform3d` class to fix this behavior. The least invasive way to do it I can think of consists of creating an empty instance of the current class, then setting the `_matrix` attribute manually. Thus, instead of  
```python
return self.__class__(matrix=self.get_matrix()[index])
```
I propose to do:
```python
instance = self.__class__.__new__(self.__class__)
instance._matrix = self.get_matrix()[index]
return instance
```

As far as I can tell, this modification occurs no modification whatsoever for the user, except for the ability to index all 3d transforms.
