### PR TITLE
Correct "hetereogenous" to "heterogeneous"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PyTorch3D is designed to integrate smoothly with deep learning methods for predi
 For this reason, all operators in PyTorch3D:
 
 - Are implemented using PyTorch tensors
-- Can handle minibatches of hetereogenous data
+- Can handle minibatches of heterogeneous data
 - Can be differentiated
 - Can utilize GPUs for acceleration
 


### PR DESCRIPTION
This pull request corrects a typo in the documentation. The word "hetereogenous" has been corrected to "heterogeneous" to improve clarity and accuracy in the text.