### PR TITLE
added texture mode on load_obj

### DIFF
--- a/pytorch3d/datasets/shapenet_base.py
+++ b/pytorch3d/datasets/shapenet_base.py
@@ -45,6 +45,7 @@ class ShapeNetBase(torch.utils.data.Dataset):  # pragma: no cover
         self.model_dir = "model.obj"
         self.load_textures = True
         self.texture_resolution = 4
+        self.texture_mode = "clamp"
 
     def __len__(self) -> int:
         """
@@ -90,6 +91,7 @@ class ShapeNetBase(torch.utils.data.Dataset):  # pragma: no cover
             create_texture_atlas=self.load_textures,
             load_textures=self.load_textures,
             texture_atlas_size=self.texture_resolution,
+            texture_mode = self.texture_mode
         )
         if self.load_textures:
             textures = aux.texture_atlas


### PR DESCRIPTION
ShapeNetCore throws error texture UV coordinates are outside the range [0,1], this fixes it by clamping it with the clamp texture mode.