### PR TITLE
Correct "fast" `matrix_to_axis_angle` near pi

### DIFF
--- a/pytorch3d/transforms/rotation_conversions.py
+++ b/pytorch3d/transforms/rotation_conversions.py
@@ -542,9 +542,7 @@ def matrix_to_axis_angle(matrix: torch.Tensor, fast: bool = False) -> torch.Tens
     zeros = torch.zeros(3, dtype=matrix.dtype, device=matrix.device)
     omegas = torch.where(torch.isclose(angles, torch.zeros_like(angles)), zeros, omegas)
 
-    near_pi = torch.isclose(((traces - 1) / 2).abs(), torch.ones_like(traces)).squeeze(
-        -1
-    )
+    near_pi = torch.isclose(angles, torch.full_like(angles, torch.pi)).squeeze(-1)
 
     axis_angles = torch.empty_like(omegas)
     axis_angles[~near_pi] = (

--- a/pytorch3d/transforms/rotation_conversions.py
+++ b/pytorch3d/transforms/rotation_conversions.py
@@ -542,7 +542,7 @@ def matrix_to_axis_angle(matrix: torch.Tensor, fast: bool = False) -> torch.Tens
     zeros = torch.zeros(3, dtype=matrix.dtype, device=matrix.device)
     omegas = torch.where(torch.isclose(angles, torch.zeros_like(angles)), zeros, omegas)
 
-    near_pi = torch.isclose(angles, torch.full_like(angles, torch.pi)).squeeze(-1)
+    near_pi = angles.isclose(angles.new_tensor(torch.pi)).squeeze(-1)
 
     axis_angles = torch.empty_like(omegas)
     axis_angles[~near_pi] = (


### PR DESCRIPTION
A continuation of #1948 -- this commit fixes a small numerical issue with `matrix_to_axis_angle(..., fast=True)` near `pi`.
@bottler feel free to check this out, it's a single-line change.