### PR TITLE
Fix parse_image_size when using a batch of PerspectiveCameras

### DIFF
--- a/pytorch3d/renderer/utils.py
+++ b/pytorch3d/renderer/utils.py
@@ -438,7 +438,7 @@ def ndc_to_grid_sample_coords(
 
 
 def parse_image_size(
-    image_size: Union[List[int], Tuple[int, int], int],
+    image_size: Union[torch.Tensor, List[int], Tuple[int, int], int]
 ) -> Tuple[int, int]:
     """
     Args:
@@ -450,6 +450,8 @@ def parse_image_size(
     Throws:
         ValueError if got more than two ints, any negative numbers or non-ints.
     """
+    if isinstance(image_size, torch.Tensor):
+        return parse_image_size(image_size.tolist()[0])
     if not isinstance(image_size, (tuple, list)):
         return (image_size, image_size)
     if len(image_size) != 2:


### PR DESCRIPTION
When creating a batch of PerspectiveCameras, directly or using cameras_from_opencv_projection, it requires the image_size at least to be a Tensor with the batch dim (1, 2) or (B, 2). However, the parse_image_size cannnot properly handle this unexpected input, and will throw an error during the rendering forward pass. 