### PR TITLE
Security: Out-of-bounds tensor access from unvalidated edge indices

### DIFF
--- a/pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp
+++ b/pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp
@@ -17,6 +17,20 @@ at::Tensor GatherScatterCpu(
   const auto input_feature_dim = input.size(1);
   const auto num_edges = edges.size(0);
 
+  if (num_edges > 0) {
+    const auto min_edge_idx = edges.min().item<int64_t>();
+    const auto max_edge_idx = edges.max().item<int64_t>();
+    TORCH_CHECK(
+        min_edge_idx >= 0 && max_edge_idx < num_vertices,
+        "Edges have invalid vertex indices. Expected indices in [0, ",
+        num_vertices,
+        "), but got [",
+        min_edge_idx,
+        ", ",
+        max_edge_idx,
+        "].");
+  }
+
   auto output = at::zeros({num_vertices, input_feature_dim}, input.options());
 
   auto input_a = input.accessor<float, 2>();


### PR DESCRIPTION
## Problem

The CPU gather/scatter kernel reads vertex indices from `edges` and directly indexes `output_a[v0]`, `output_a[v1]`, `input_a[v1]`, and `input_a[v0]` without validating bounds. A crafted `edges` tensor containing negative or too-large indices can trigger out-of-bounds reads/writes, leading to crashes or memory corruption in the extension process.

**Severity**: `high`
**File**: `pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp`

## Solution

Before the loop, validate `edges` index range with `TORCH_CHECK` (e.g., min >= 0 and max < num_vertices). Keep the same validation in CUDA and CPU paths, and fail fast on invalid input.

## Changes

- `pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
