### PR TITLE
Security: Unsafe reinterpret_cast for Camera Gradient Data

### DIFF
--- a/pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h
+++ b/pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h
@@ -24,6 +24,12 @@ namespace Renderer {
 template <bool DEV>
 GLOBAL void norm_cam_gradients(Renderer renderer) {
   GET_PARALLEL_IDX_1D(idx, 1);
+  static_assert(
+      alignof(CamGradInfo) <= alignof(float),
+      "CamGradInfo alignment must not exceed float alignment.");
+  static_assert(
+      sizeof(CamGradInfo) % sizeof(float) == 0,
+      "CamGradInfo size must be a multiple of float size.");
   CamGradInfo* cgi = reinterpret_cast<CamGradInfo*>(renderer.grad_cam_d);
   *cgi = *cgi * FRCP(static_cast<float>(*renderer.n_grad_contributions_d));
   END_PARALLEL_NORET();


### PR DESCRIPTION
## Problem

In `renderer.norm_cam_gradients.device.h`, `reinterpret_cast<CamGradInfo*>(renderer.grad_cam_d)` is used to reinterpret a `float*` as a `CamGradInfo*`. If the underlying memory is not properly aligned or sized for `CamGradInfo`, this results in undefined behavior, potentially leading to memory corruption or incorrect gradient computation.

**Severity**: `medium`
**File**: `pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h`

## Solution

Ensure that `renderer.grad_cam_d` is allocated with proper size and alignment for `CamGradInfo`. Consider using a typed member instead of reinterpret_cast, or add static_assert checks for size/alignment compatibility.

## Changes

- `pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
