### PR TITLE
Security: Unclosed File Handle in YAML Loading

### DIFF
--- a/.circleci/build_count.py
+++ b/.circleci/build_count.py
@@ -14,7 +14,8 @@ from collections import Counter
 import yaml
 
 
-conf = yaml.safe_load(open("config.yml"))
+with open("config.yml") as f:
+    conf = yaml.safe_load(f)
 jobs = conf["workflows"]["build_and_test"]["jobs"]
 
 


### PR DESCRIPTION
## Problem

In `build_count.py`, `yaml.safe_load(open('config.yml'))` opens a file but never explicitly closes the file handle. While `yaml.safe_load` is used (avoiding YAML deserialization attacks), the file descriptor leak could be problematic in long-running processes or resource-constrained environments.

**Severity**: `low`
**File**: `.circleci/build_count.py`

## Solution

Use a context manager: `with open('config.yml') as f: conf = yaml.safe_load(f)`

## Changes

- `.circleci/build_count.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
