### PR TITLE
Security: Out-of-bounds array access in GatherScatterCpu due to unchecked edge indices

### DIFF
--- a/pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp
+++ b/pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp
@@ -30,6 +30,10 @@ at::Tensor GatherScatterCpu(
     const int64_t v0 = edges_a[e][v0_idx];
     const int64_t v1 = edges_a[e][v1_idx];
 
+    TORCH_CHECK(
+        v0 >= 0 && v0 < num_vertices && v1 >= 0 && v1 < num_vertices,
+        "Edge vertex index out of bounds");
+
     for (int d = 0; d < input_feature_dim; ++d) {
       output_a[v0][d] += input_a[v1][d];
       if (!directed) {


### PR DESCRIPTION
## Problem

The function `GatherScatterCpu` reads vertex indices `v0` and `v1` from the `edges` tensor and uses them directly to index into the `input` and `output` arrays without validating that they fall within `[0, num_vertices)`. A malformed `edges` tensor with indices exceeding the vertex count could lead to out-of-bounds memory reads and writes, potentially causing memory corruption or information disclosure.

**Severity**: `high`
**File**: `pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp`

## Solution

Add bounds checks before accessing arrays with edge-derived indices: `TORCH_CHECK(v0 >= 0 && v0 < num_vertices && v1 >= 0 && v1 < num_vertices, "Edge vertex index out of bounds");`

## Changes

- `pytorch3d/csrc/gather_scatter/gather_scatter_cpu.cpp` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
