### PR TITLE
Security: Potential division by zero in norm_cam_gradients

### DIFF
--- a/pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h
+++ b/pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h
@@ -25,7 +25,9 @@ template <bool DEV>
 GLOBAL void norm_cam_gradients(Renderer renderer) {
   GET_PARALLEL_IDX_1D(idx, 1);
   CamGradInfo* cgi = reinterpret_cast<CamGradInfo*>(renderer.grad_cam_d);
-  *cgi = *cgi * FRCP(static_cast<float>(*renderer.n_grad_contributions_d));
+  if (*renderer.n_grad_contributions_d > 0) {
+    *cgi = *cgi * FRCP(static_cast<float>(*renderer.n_grad_contributions_d));
+  }
   END_PARALLEL_NORET();
 };
 


### PR DESCRIPTION
## Problem

The `norm_cam_gradients` kernel divides by `*renderer.n_grad_contributions_d` using `FRCP(static_cast<float>(...))`. If no spheres contributed to the gradient (i.e., the value is 0), this results in a division by zero, producing `inf` or `NaN` values that can propagate and corrupt downstream computations.

**Severity**: `medium`
**File**: `pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h`

## Solution

Add a guard before the division: `if (*renderer.n_grad_contributions_d > 0) { *cgi = *cgi * FRCP(static_cast<float>(*renderer.n_grad_contributions_d)); }`

## Changes

- `pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
