### PR TITLE
Security: Unsafe reinterpret_cast of raw pointer without size or alignment validation

### DIFF
--- a/pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h
+++ b/pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h
@@ -24,6 +24,12 @@ namespace Renderer {
 template <bool DEV>
 GLOBAL void norm_cam_gradients(Renderer renderer) {
   GET_PARALLEL_IDX_1D(idx, 1);
+  static_assert(
+      sizeof(CamGradInfo) % sizeof(float) == 0,
+      "CamGradInfo size must be a multiple of sizeof(float).");
+  static_assert(
+      alignof(CamGradInfo) <= alignof(float),
+      "CamGradInfo alignment must not exceed float alignment.");
   CamGradInfo* cgi = reinterpret_cast<CamGradInfo*>(renderer.grad_cam_d);
   *cgi = *cgi * FRCP(static_cast<float>(*renderer.n_grad_contributions_d));
   END_PARALLEL_NORET();


### PR DESCRIPTION
## Problem

In `norm_cam_gradients`, `renderer.grad_cam_d` (a raw float pointer) is reinterpret_cast to `CamGradInfo*` without any validation that the underlying memory is correctly sized or aligned for `CamGradInfo`. If the allocated buffer for `grad_cam_d` is smaller than `sizeof(CamGradInfo)`, this leads to out-of-bounds memory access. Similarly, misalignment could cause undefined behavior on certain platforms.

**Severity**: `medium`
**File**: `pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h`

## Solution

Add a static_assert or runtime check ensuring `sizeof(CamGradInfo)` matches the expected buffer size, and that alignment requirements are satisfied.

## Changes

- `pytorch3d/csrc/pulsar/include/renderer.norm_cam_gradients.device.h` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
