### PR TITLE
Security: Type punning via IASF macro causes undefined behavior

### DIFF
--- a/pytorch3d/csrc/pulsar/include/renderer.fill_bg.device.h
+++ b/pytorch3d/csrc/pulsar/include/renderer.fill_bg.device.h
@@ -9,6 +9,8 @@
 #ifndef PULSAR_NATIVE_INCLUDE_RENDERER_FILL_BG_DEVICE_H_
 #define PULSAR_NATIVE_INCLUDE_RENDERER_FILL_BG_DEVICE_H_
 
+#include <cstring>
+
 #include "../global.h"
 #include "./camera.h"
 #include "./commands.h"
@@ -41,7 +43,7 @@ GLOBAL void fill_bg(
     // sphere IDs and intersection depths.
     for (int i = 0; i < renderer.n_track; ++i) {
       int sphere_id = -1;
-      IASF(sphere_id, renderer.forw_info_d[write_loc + 3 + i * 2]);
+      memcpy(&renderer.forw_info_d[write_loc + 3 + i * 2], &sphere_id, sizeof(float));
       renderer.forw_info_d[write_loc + 3 + i * 2 + 1] = -1.f;
     }
     if (mode == 0) {


### PR DESCRIPTION
## Problem

In `renderer.fill_bg.device.h`, the `IASF` macro is used to store an integer value (`sphere_id = -1`) into a float memory location via type punning. This is undefined behavior in C++ unless performed through `memcpy` or `std::bit_cast`. Compilers may optimize this incorrectly under strict aliasing rules, leading to unpredictable behavior.

**Severity**: `low`
**File**: `pytorch3d/csrc/pulsar/include/renderer.fill_bg.device.h`

## Solution

Use `memcpy` for type punning instead of the IASF macro to ensure well-defined behavior: `memcpy(&renderer.forw_info_d[write_loc + 3 + i * 2], &sphere_id, sizeof(float));`

## Changes

- `pytorch3d/csrc/pulsar/include/renderer.fill_bg.device.h` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
