### PR TITLE
Improve modern packaging compatibility for local source builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = [
+    "setuptools>=64",
+    "wheel",
+    "torch",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pytorch3d"
+version = "0.7.9"
+description = "PyTorch3D is FAIR's library of reusable components for deep learning with 3D data."
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["iopath"]
+dynamic = ["authors", "optional-dependencies", "scripts"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,33 @@ version = "0.7.9"
 description = "PyTorch3D is FAIR's library of reusable components for deep learning with 3D data."
 readme = "README.md"
 requires-python = ">=3.8"
+authors = [{ name = "FAIR" }]
 dependencies = ["iopath"]
-dynamic = ["authors", "optional-dependencies", "scripts"]
+
+[project.optional-dependencies]
+all = ["matplotlib", "tqdm>4.29.0", "imageio", "ipywidgets"]
+dev = ["flake8", "usort"]
+implicitron = [
+    "hydra-core>=1.1",
+    "visdom",
+    "lpips",
+    "tqdm>4.29.0",
+    "matplotlib",
+    "accelerate",
+    "sqlalchemy>=2.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/facebookresearch/pytorch3d"
+Repository = "https://github.com/facebookresearch/pytorch3d"
+
+[project.scripts]
+pytorch3d_implicitron_runner = "pytorch3d.implicitron_trainer.experiment:experiment"
+pytorch3d_implicitron_visualizer = "pytorch3d.implicitron_trainer.visualize_reconstruction:main"
+
+[tool.setuptools]
+package-dir = { "pytorch3d.implicitron_trainer" = "projects/implicitron_trainer" }
+package-data = { "*" = ["*.json"] }
+
+[tool.setuptools.packages.find]
+exclude = ["configs", "tests", "tests.*", "docs.*", "projects.*"]

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ def get_extensions():
 
         extra_compile_args["nvcc"] = nvcc_args
 
-    sources = [os.path.join(extensions_dir, s) for s in sources]
+    sources = [os.path.relpath(s, this_dir) for s in sources]
 
     ext_modules = [
         extension(


### PR DESCRIPTION
Fixes #2036

## Summary

This PR improves PyTorch3D compatibility with modern Python packaging workflows.

## Changes

- add a minimal `pyproject.toml` using `setuptools.build_meta`
- declare core static project metadata in `pyproject.toml`
- declare `authors`, `optional-dependencies`, and `scripts` as `dynamic`
- change extension source paths in `setup.py` from absolute paths to paths relative to the project root

## Why

Modern build frontends are stricter than legacy `setup.py install` flows.

In particular:
- setuptools local/editable builds reject absolute extension source paths
- modern frontends work better when minimal project metadata is available through `pyproject.toml`

These changes improve packaging compatibility without changing the runtime API.

## Validation

Validated with a local source install through `uv` using a matching PyTorch / CUDA combination:

```bash
tmpdir=$(mktemp -d)
uv venv "$tmpdir/venv"

UV_HTTP_TIMEOUT=300 uv pip install --python "$tmpdir/venv/bin/python" \
  --index-strategy unsafe-best-match \
  setuptools wheel numpy iopath torch==2.10.0+cu128 \
  --index-url https://pypi.org/simple \
  --extra-index-url https://download.pytorch.org/whl/cu128

UV_HTTP_TIMEOUT=300 CUDA_HOME=/usr/local/cuda-12.8 \
PATH="/usr/local/cuda-12.8/bin:$PATH" \
uv pip install --python "$tmpdir/venv/bin/python" \
  /path/to/pytorch3d \
  --no-build-isolation
```

This completed successfully and built `pytorch3d` from local source.