### PR TITLE
Security: Missing tensor shape and dtype validation before native accessors

### DIFF
--- a/pytorch3d/csrc/gather_scatter/gather_scatter.h
+++ b/pytorch3d/csrc/gather_scatter/gather_scatter.h
@@ -44,6 +44,12 @@ at::Tensor GatherScatter(
     const at::Tensor& edges,
     bool directed,
     bool backward) {
+  TORCH_CHECK(input.device() == edges.device(), "input and edges must be on the same device");
+  TORCH_CHECK(input.dim() == 2, "input must be a 2D tensor");
+  TORCH_CHECK(input.scalar_type() == at::ScalarType::Float, "input must be a float32 tensor");
+  TORCH_CHECK(edges.dim() == 2, "edges must be a 2D tensor");
+  TORCH_CHECK(edges.scalar_type() == at::ScalarType::Long, "edges must be an int64 tensor");
+  TORCH_CHECK(edges.size(1) == 2, "edges must have shape (E, 2)");
   if (input.is_cuda() && edges.is_cuda()) {
 #ifdef WITH_CUDA
     CHECK_CUDA(input);


### PR DESCRIPTION
## Summary

Security: Missing tensor shape and dtype validation before native accessors

## Problem

**Severity**: `Medium` | **File**: `pytorch3d/csrc/gather_scatter/gather_scatter.h:L39`

The exposed `GatherScatter` wrapper dispatches directly to CPU/CUDA implementations without checking that `input` is a 2D float tensor and `edges` is a 2D int64 tensor with second dimension equal to 2. The CPU implementation immediately creates `accessor<float, 2>()` and `accessor<int64_t, 2>()`; invalid tensors can trigger native exceptions or undefined behavior depending on compilation and PyTorch checks. This is especially risky for public Python extension APIs that may receive untrusted tensors.

## Solution

Add explicit `TORCH_CHECK` validation in the public wrapper before dispatch: check device consistency, dimensionality, dtype, contiguity if required, and `edges.size(1) == 2`. Prefer failing with clear Python exceptions before constructing unchecked native accessors.

## Changes

- `pytorch3d/csrc/gather_scatter/gather_scatter.h` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced

---
*Generated by [ContribAI](https://github.com/tang-vu/ContribAI) v6.8.0*