### PR TITLE
Fix CPU marching cubes precision and topology at high resolutions (#1934)

### DIFF
--- a/pytorch3d/csrc/marching_cubes/marching_cubes_cpu.cpp
+++ b/pytorch3d/csrc/marching_cubes/marching_cubes_cpu.cpp
@@ -66,19 +66,23 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> MarchingCubesCpu(
           tri.push_back(edge);
           ps.push_back(interp_points[e]);
 
-          // Check if the triangle face is degenerate. A triangle face
-          // is degenerate if any of the two verices share the same 3D position
-          if ((j + 1) % 3 == 0 && ps[0] != ps[1] && ps[1] != ps[2] &&
-              ps[2] != ps[0]) {
-            for (int k = 0; k < 3; k++) {
-              int64_t v = tri.at(k);
-              edge_id_to_v[v] = ps.at(k);
-              if (!uniq_edge_id.count(v)) {
-                uniq_edge_id[v] = verts.size();
-                verts.push_back(edge_id_to_v[v]);
+          if (ps.size() == 3) {
+            // Check if the triangle face is degenerate. A triangle face
+            // is degenerate if any of the two vertices share the same 3D
+            // position
+            if (ps[0] != ps[1] && ps[1] != ps[2] && ps[2] != ps[0]) {
+              for (int k = 0; k < 3; k++) {
+                int64_t v = tri.at(k);
+                edge_id_to_v[v] = ps.at(k);
+                if (!uniq_edge_id.count(v)) {
+                  uniq_edge_id[v] = verts.size();
+                  verts.push_back(edge_id_to_v[v]);
+                }
+                faces.push_back(uniq_edge_id[v]);
               }
-              faces.push_back(uniq_edge_id[v]);
             }
+            // Clear unconditionally - a rejected degenerate triangle must not
+            // corrupt the buffer for the next triangle in this cube.
             tri.clear();
             ps.clear();
           } // endif

--- a/pytorch3d/csrc/marching_cubes/marching_cubes_utils.h
+++ b/pytorch3d/csrc/marching_cubes/marching_cubes_utils.h
@@ -135,11 +135,19 @@ struct Cube {
   // Returns:
   //    hashing for a pair of vertex ids
   //
-  int64_t HashVpair(const int edge, int W, int H, int D) {
+  int64_t HashVpair(const int edge, int64_t W, int64_t H, int64_t D) {
     const int v1 = _EDGE_TO_VERTICES[edge][0];
     const int v2 = _EDGE_TO_VERTICES[edge][1];
-    const int v1_id = p[v1].x + p[v1].y * W + p[v1].z * W * H;
-    const int v2_id = p[v2].x + p[v2].y * W + p[v2].z * W * H;
-    return (int64_t)v1_id * (W + W * H + W * H * D) + (int64_t)v2_id;
+    // p[v].x/y/z hold integral corner coordinates, so casting to int64_t is
+    // exact. We cast before multiplication to avoid float32 precision loss at
+    // grids > 256^3.
+    const int64_t v1_id =
+        (int64_t)p[v1].x + (int64_t)p[v1].y * W + (int64_t)p[v1].z * W * H;
+    const int64_t v2_id =
+        (int64_t)p[v2].x + (int64_t)p[v2].y * W + (int64_t)p[v2].z * W * H;
+    // v_id max is (W*H*D - 1). A stride of W*H*D perfectly separates v1 and v2.
+    // Note: This hash fits in int64_t safely up to grids of ~1448^3.
+    const int64_t stride = W * H * D;
+    return v1_id * stride + v2_id;
   }
 };

--- a/pytorch3d/ops/marching_cubes.py
+++ b/pytorch3d/ops/marching_cubes.py
@@ -159,7 +159,6 @@ def marching_cubes_naive(
     """
     batched_verts, batched_faces = [], []
     D, H, W = vol_batch.shape[1:]
-
     # each edge is represented with its two endpoints (represented with global id)
     for i in range(len(vol_batch)):
         vol = vol_batch[i]
@@ -184,7 +183,7 @@ def marching_cubes_naive(
                     # triangle vertex IDs and positions
                     tri = []
                     ps = []
-                    for i, edge in enumerate(edge_indices):
+                    for edge in edge_indices:
                         interp_points[edge] = cube.vert_interp(thresh, edge, vol)
 
                         # Bind interpolated vertex with a global edge_id, which
@@ -196,20 +195,17 @@ def marching_cubes_naive(
                         )
                         tri.append(edge_id)
                         ps.append(interp_points[edge])
-                        # when the isolevel are the same as the edge endpoints, the interploated
-                        # vertices can share the same values, and lead to degenerate triangles.
-                        if (
-                            (i + 1) % 3 == 0
-                            and ps[0] != ps[1]
-                            and ps[1] != ps[2]
-                            and ps[2] != ps[0]
-                        ):
-                            for j, edge_id in enumerate(tri):
-                                edge_id_to_v[edge_id] = ps[j]
-                                if edge_id not in uniq_edge_id:
-                                    uniq_edge_id[edge_id] = len(verts)
-                                    verts.append(edge_id_to_v[edge_id])
-                            faces.append([uniq_edge_id[tri[j]] for j in range(3)])
+                        if len(ps) == 3:
+                            # when the isolevel are the same as the edge endpoints, the interpolated
+                            # vertices can share the same values, and lead to degenerate triangles.
+                            if ps[0] != ps[1] and ps[1] != ps[2] and ps[2] != ps[0]:
+                                for j, edge_id in enumerate(tri):
+                                    edge_id_to_v[edge_id] = ps[j]
+                                    if edge_id not in uniq_edge_id:
+                                        uniq_edge_id[edge_id] = len(verts)
+                                        verts.append(edge_id_to_v[edge_id])
+                                faces.append([uniq_edge_id[tri[j]] for j in range(3)])
+
                             tri = []
                             ps = []
 


### PR DESCRIPTION
Fixes #1934. Two independent bugs in the CPU backend.

### 1. Degenerate-triangle filter discards valid faces

`marching_cubes_cpu.cpp`, `marching_cubes.py`

`tri.clear()` and `ps.clear()` sit inside the degeneracy check, so the buffers only reset when a triangle is *accepted*. Once a cube's first triangle is degenerate, `ps[0..2]` stay frozen on it, and every subsequent triangle in that cube fails the same stale check and is dropped.

Fixed by gating on `ps.size() == 3` and clearing unconditionally. The old code could only ever drop faces, never emit incorrect ones, so this is strictly additive.

### 2. Edge hash computed in float32

`marching_cubes_utils.h`

`p[v].x/y/z` hold integral coordinates but are stored as `float`, so `x + y*W + z*W*H` evaluates entirely in float32 before truncating to `int`. float32 is exact only to 2²⁴ − 1 = 16,777,215 — and 256³ maxes out at exactly that value. At 512³ the maximum id is 134,217,727, where float32 spacing is 8, so distinct vertices collide on one id and `uniq_edge_id` merges them.

Fixed by widening `W/H/D` to `int64_t` and casting each coordinate before multiplying. Also tightens the stride from `(W + W*H + W*H*D)` to `W*H*D`. Raises the ceiling from 256³ to 1448³. `marching_cubes_naive` is unaffected (Python ints are arbitrary-precision).

### Verification

Ellipsoid SDF (0.1, 1, 1), `isolevel=0.0`, identical input tensors on both devices.

| Resolution | CUDA V | CUDA F | CPU V | CPU F | Degenerate dropped |
| -- | -- | -- | -- | -- | -- |
| 32³ | 1,664 | 3,324 | 1,664 | 3,324 | 0 |
| 64³ | 7,312 | 14,620 | 7,312 | 14,620 | 0 |
| 128³ | 30,168 | 60,332 | 30,168 | 60,332 | 0 |
| 256³ | 122,448 | 244,892 | 122,448 | 243,996 | 896 |
| 512³ | 491,944 | 983,884 | 491,944 | 976,140 | 7,744 |

Machine: Arch Linux, RTX 4080, Ryzen 7 7800X3D

Vertex counts now match CUDA exactly at every resolution; 512³ previously produced 176,121. The remaining face gap is entirely degenerate geometry — the CUDA mesh at 512³ contains exactly 7,744 zero-area triangles.

### Tests

A regression test for each bug, plus CPU/naive parity. Bug 2 is tested against `HashVpair` directly rather than by allocating a large volume. Existing expectations in `test_marching_cubes.py` are updated where Bug 1 changes output.

*Analysis and write-up done collaboratively with AI, figures from testing are done on my own machine and have been checked.*