### PR TITLE
Fix coordinate indexing in frustum face culling

### DIFF
--- a/pytorch3d/renderer/mesh/clip.py
+++ b/pytorch3d/renderer/mesh/clip.py
@@ -10,7 +10,6 @@ from typing import Any, List, Optional, Tuple
 
 import torch
 
-
 """
 Mesh clipping is done before rasterization and is implemented using 4 cases
 (these will be referred to throughout the functions below)
@@ -187,12 +186,12 @@ def _get_culled_faces(face_verts: torch.Tensor, frustum: ClipFrustum) -> torch.T
         # If clip_value is None then don't clip along that plane
         if frustum.cull and clip_value is not None:
             if op == "<":
-                verts_clipped = face_verts[:, axis] < clip_value
+                verts_clipped = face_verts[:, :, axis] < clip_value
             else:
-                verts_clipped = face_verts[:, axis] > clip_value
+                verts_clipped = face_verts[:, :, axis] > clip_value
 
             # If all verts are clipped then face is outside the frustum
-            faces_culled |= verts_clipped.sum(1) == 3
+            faces_culled |= verts_clipped.all(dim=1)
 
     return faces_culled
 

--- a/tests/test_render_meshes_clipped.py
+++ b/tests/test_render_meshes_clipped.py
@@ -31,6 +31,7 @@ from pytorch3d.renderer.mesh import (
     convert_clipped_rasterization_to_original_faces,
     TexturesUV,
 )
+from pytorch3d.renderer.mesh.clip import _get_culled_faces
 from pytorch3d.renderer.mesh.rasterize_meshes import _RasterizeFaceVerts
 from pytorch3d.renderer.mesh.rasterizer import MeshRasterizer, RasterizationSettings
 from pytorch3d.renderer.mesh.renderer import MeshRenderer
@@ -40,7 +41,6 @@ from pytorch3d.structures.meshes import Meshes
 from pytorch3d.utils import torus
 
 from .common_testing import get_tests_dir, load_rgb_image, TestCaseMixin
-
 
 # If DEBUG=True, save out images generated in the tests for debugging.
 # All saved images have prefix DEBUG_
@@ -193,6 +193,35 @@ class TestRenderMeshesClipping(TestCaseMixin, unittest.TestCase):
             face_verts, mesh_to_face_first_idx, num_faces_per_mesh, frustum
         )
         return clipped_faces
+
+    def test_cull_faces_uses_coordinate_axis(self):
+        planes_and_faces = (
+            ({"left": -1.0}, [-2.0, 0.0, 1.0]),
+            ({"right": 1.0}, [2.0, 0.0, 1.0]),
+            ({"top": -1.0}, [0.0, -2.0, 1.0]),
+            ({"bottom": 1.0}, [0.0, 2.0, 1.0]),
+            ({"znear": 0.0}, [0.0, 0.0, -1.0]),
+            ({"zfar": 2.0}, [0.0, 0.0, 3.0]),
+        )
+        for frustum_kwargs, vertex in planes_and_faces:
+            with self.subTest(frustum_kwargs=frustum_kwargs):
+                face_verts = torch.tensor([[vertex, vertex, vertex]])
+                faces_culled = _get_culled_faces(
+                    face_verts, ClipFrustum(**frustum_kwargs)
+                )
+                self.assertEqual(faces_culled, torch.tensor([True]))
+
+        # A face intersecting the left plane must remain visible regardless of
+        # which of its vertices is first in the face.
+        face_verts = torch.tensor(
+            [[[-2.0, -2.0, -2.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]]
+        )
+        for order in ([0, 1, 2], [1, 2, 0], [2, 0, 1]):
+            with self.subTest(order=order):
+                faces_culled = _get_culled_faces(
+                    face_verts[:, order], ClipFrustum(left=-1.0)
+                )
+                self.assertEqual(faces_culled, torch.tensor([False]))
 
     def test_grad(self):
         """


### PR DESCRIPTION
## Summary

Fixes the coordinate indexing used by frustum face culling.

`face_verts` has shape `[F, 3, 3]`, where the last two dimensions are vertex and xyz coordinate respectively. `_get_culled_faces` previously indexed it as `face_verts[:, axis]`, which selected one vertex from every face instead of selecting the requested coordinate from all three vertices. The subsequent reduction could therefore miss faces fully outside a clipping plane and cull faces that only had one outside vertex.

This change selects the coordinate with `face_verts[:, :, axis]` and uses `all(dim=1)` to express the intended condition directly: a face is culled only when all three vertices lie outside the same frustum plane.

The regression test covers all six frustum planes and verifies that a face intersecting the left plane stays visible for three different vertex orders.

Fixes #1936.

## Validation

- The focused regression test passes with all 9 subcases; the pre-fix implementation fails 7 of them.
- An independent oracle over 4,096 seeded random triangles has zero mismatches with the fix. The previous implementation produces 604 false positives and 603 false negatives on the same inputs.
- Black, usort, flake8, and `git diff --check` pass for the changed files.
- The remaining tests in `tests/test_render_meshes_clipped.py` require CUDA and cannot run in the local CPU-only PyTorch environment; the focused regression is CPU-only, and the repository CI will cover the CUDA test matrix.
